### PR TITLE
Added override data control to current-state node

### DIFF
--- a/nodes/current-state/current-state.html
+++ b/nodes/current-state/current-state.html
@@ -13,6 +13,7 @@
             halt_if: { value: '' },
             override_topic: { value: true },
             override_payload: { value: true },
+            override_data: { value: true },
             entity_id: { value: '' },
         },
         oneditprepare: function () {
@@ -97,6 +98,12 @@
         <label for="node-input-override_payload">&nbsp;</label>
         <input type="checkbox" id="node-input-override_payload" checked style="display:inline-block; width:15px; vertical-align:baseline;">&nbsp;
         <span>Override Payload</span>
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-override_data">&nbsp;</label>
+        <input type="checkbox" id="node-input-override_data" checked style="display:inline-block; width:15px; vertical-align:baseline;">&nbsp;
+        <span>Override Data</span>
     </div>
 
     <div class="form-row">

--- a/nodes/current-state/current-state.js
+++ b/nodes/current-state/current-state.js
@@ -9,6 +9,7 @@ module.exports = function(RED) {
             halt_if: {},
             override_topic: {},
             override_payload: {},
+            override_data: {},
             entity_id: {},
             server: { isNode: true }
         },
@@ -74,11 +75,11 @@ module.exports = function(RED) {
             // default switch to true if undefined (backward compatibility
             const override_payload = this.nodeConfig.override_payload !== false;
             const override_topic = this.nodeConfig.override_topic !== false;
+            const override_data = this.nodeConfig.override_data !== false;
 
             if (override_topic) message.topic = entity_id;
             if (override_payload) message.payload = currentState.state;
-
-            message.data = currentState;
+            if (override_data) message.data = currentState;
 
             this.status({
                 fill: 'green',


### PR DESCRIPTION
  - Default should preserve current behavior
  - The change allows the node to fully pass-thru the input
    message to the output, but preserves the halt ability of the node

Signed-off-by: Jason Albert <jtalbert@gmail.com>