### PR TITLE
Update README to reflect hass.io config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node Red Contrib Home Assistant Websocket
 
-[![Build Status](https://travis-ci.com/zachowj/node-red-contrib-home-assistant-websocket.svg?branch=master)](https://travis-ci.com/zachowj/node-red-contrib-home-assistant-websocket) [![Coverage Status](https://coveralls.io/repos/github/zachowj/node-red-contrib-home-assistant-websocket/badge.svg?branch=master)](https://coveralls.io/github/zachowj/node-red-contrib-home-assistant-websocket?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/zachowj/node-red-contrib-home-assistant-websocket.svg)](https://greenkeeper.io/)
+[![Build Status](https://travis-ci.com/zachowj/node-red-contrib-home-assistant-websocket.svg?branch=master)](https://travis-ci.com/zachowj/node-red-contrib-home-assistant-websocket) [![Coverage Status](https://coveralls.io/repos/github/zachowj/node-red-contrib-home-assistant-websocket/badge.svg?branch=master)](https://coveralls.io/github/zachowj/node-red-contrib-home-assistant-websocket?branch=master)
 
 Various nodes to assist in setting up automation using [node-red](https://nodered.org/) communicating with [Home Assistant](https://home-assistant.io/).
 
@@ -10,7 +10,7 @@ Project is going through active development and as such will probably have a few
 
 ## Getting Started
 
-This assumes you have [node-red](http://nodered.org/) already installed and working, if you need to install node-red see [here](http://nodered.org/docs/getting-started/installation)
+This assumes you have [node-red](https://nodered.org/) already installed and working, if you need to install node-red see [here](https://nodered.org/docs/getting-started/installation)
 
 #### NOTE: node-red-contrib-home-assistant-websocket requires node.JS >= 8.12.0. If you're running Node-Red in Docker you'll need to pull the -v8 image for this to work.
 
@@ -32,7 +32,7 @@ For [Hass.io](https://hass.io/) add-on users:
 
 The Community Hass.io add-on ships with this node right out of the box.
 
-Use the Hass.io API Proxy address `http://hassio/homeassistant` as the Home Assistant server address (Base URL, which is the default on installing the add-on the first time). The access token field can be left empty as the plugin will fill it in with the HASSIO_TOKEN when you deploy your flows.
+Under the server node config just check the checkbox for `I use Hass.io`
 
 The add-on can be found here: <https://github.com/hassio-addons/addon-node-red#readme>
 

--- a/lib/ha-api.js
+++ b/lib/ha-api.js
@@ -1,5 +1,6 @@
 'use strict';
 const axios = require('axios');
+const https = require('https');
 const utils = require('./utils');
 const debug = require('debug')('home-assistant:api');
 
@@ -12,6 +13,12 @@ class HaApi {
                 ? { 'x-ha-access': config.apiPass }
                 : {}
             : { Authorization: 'Bearer ' + config.apiPass };
+
+        if (!config.rejectUnauthorizedCerts) {
+            apiOpts.httpsAgent = new https.Agent({
+                rejectUnauthorized: false
+            });
+        }
 
         this.client = axios.create(apiOpts);
     }

--- a/lib/ha-websocket.js
+++ b/lib/ha-websocket.js
@@ -239,7 +239,10 @@ class HaWebsocket extends EventEmitter {
             debug('[Auth Phase] New connection', url);
             self.connectionState = self.CONNECTING;
             self.emit('ha_events:connecting');
-            const socket = new WebSocket(url);
+
+            const socket = new WebSocket(url, {
+                rejectUnauthorized: self.config.rejectUnauthorizedCerts
+            });
 
             // If invalid auth, we will not try to reconnect.
             let invalidAuth = false;

--- a/lib/node-home-assistant.js
+++ b/lib/node-home-assistant.js
@@ -8,6 +8,7 @@ const DEFAULTS = {
     apiPass: null,
     api: {},
     legacy: false,
+    rejectUnauthorizedCerts: true,
     websocket: {
         includeRegex: null, // Include/Exclude allows for suppressing events by regex matches
         excludeRegex: null,

--- a/nodes/config-server/config-server.html
+++ b/nodes/config-server/config-server.html
@@ -5,6 +5,7 @@
             name: { value: 'Home Assistant', required: false },
             legacy: { value: false },
             hassio: { value: false },
+            rejectUnauthorizedCerts: { value: true }
         },
         credentials: {
             host: { value: '', required: true },
@@ -16,6 +17,10 @@
             var $hassio = $("#node-config-input-hassio");
             var $host = $("#node-config-input-host");
             var $legacy = $("#node-config-input-legacy");
+
+            if (this.rejectUnauthorizedCerts === false) {
+                $("#accept_unauthorized_certs").prop('checked', true);
+            }
 
             if (!$hassio.prop("checked") && $host.val() === "http://hassio/homeassistant") {
                 $hassio.prop("checked", true);
@@ -46,6 +51,8 @@
 
             if (hassio) {
                 $host.val('http://hassio/homeassistant');
+                this.legacy = false;
+                this.rejectUnauthorizedCerts = true;
             } else {
                 var parser = document.createElement("a");
                 parser.href = hostname;
@@ -53,6 +60,9 @@
                 if (hostname !== parser.origin) {
                     RED.notify("Invalid format of Base URL: " + hostname);
                 }
+
+                // Save the inverse of the checkbox
+                this.rejectUnauthorizedCerts = !$('#accept_unauthorized_certs').prop('checked');
             }
         }
     });
@@ -84,6 +94,11 @@
             <input type="checkbox" id="node-config-input-legacy" style="width: auto;margin-left: 125px;vertical-align: top" />
             <label for="node-config-input-legacy" style="width: auto;"> Use Legacy API Password</label>
         </div>
+
+        <div class="form-row">
+            <input type="checkbox" id="accept_unauthorized_certs" style="width: auto;margin-left: 125px;vertical-align: top" />
+            <label for="accept_unauthorized_certs" style="width: auto;"> Accept Unauthorized SSL Certificates</label>
+        </div>
     </div>
 </script>
 
@@ -107,6 +122,8 @@
             <dt>Legacy Password <span class="property-type">boolean</span></dt>
             <dd>If you're using the legacy password to log into Home Assistant check this and enter your password in the password text box.</dd>
 
+            <dt>Unauthorized SSL Certificates <span class="property-type">boolean</span></dt>
+            <dd>This will allow you to use self-signed certificates. Only use this if you know what you're doing.</dd>
     </dl>
 
     <h3>Details</h3>

--- a/nodes/config-server/config-server.js
+++ b/nodes/config-server/config-server.js
@@ -29,7 +29,8 @@ module.exports = function(RED) {
         config: {
             name: {},
             legacy: {},
-            hassio: {}
+            hassio: {},
+            rejectUnauthorizedCerts: {}
         }
     };
 
@@ -89,7 +90,9 @@ module.exports = function(RED) {
                 this.homeAssistant = new HomeAssistant({
                     baseUrl: this.credentials.host,
                     apiPass: this.credentials.access_token,
-                    legacy: this.nodeConfig.legacy
+                    legacy: this.nodeConfig.legacy,
+                    rejectUnauthorizedCerts: this.nodeConfig
+                        .rejectUnauthorizedCerts
                 });
                 this.api = this.homeAssistant.api;
                 this.websocket = this.homeAssistant.websocket;


### PR DESCRIPTION
Hass.io users only need to now click the checkbox under the server config no other information is needed.