### PR TITLE
Added the ability to cast the returned state to a number or boolean

### DIFF
--- a/lib/base-node.js
+++ b/lib/base-node.js
@@ -210,6 +210,31 @@ class BaseNode {
             minute: 'numeric'
         });
     }
+
+    getCastValue(datatype, value) {
+        if (!datatype) return value;
+
+        switch (datatype) {
+            case 'num':
+                return parseFloat(value);
+            case 'str':
+                return value + '';
+            case 'bool':
+                return !!value;
+            case 'habool':
+                const haBoolean =
+                    this.nodeConfig.server.nodeConfig.ha_boolean === undefined
+                        ? `^(y|yes|true|on|home|open)$`
+                        : `^(${this.nodeConfig.server.nodeConfig.ha_boolean})$`;
+                return new RegExp(haBoolean, 'i').test(value);
+            case 're':
+                return new RegExp(value);
+            case 'list':
+                return value.split(',');
+            default:
+                return value;
+        }
+    }
 }
 
 const _internals = {

--- a/nodes/config-server/config-server.html
+++ b/nodes/config-server/config-server.html
@@ -1,105 +1,127 @@
 <script type="text/javascript">
-    RED.nodes.registerType('server', {
-        category: 'config',
-        defaults: {
-            name: { value: 'Home Assistant', required: false },
-            legacy: { value: false },
-            hassio: { value: false },
-            rejectUnauthorizedCerts: { value: true }
-        },
-        credentials: {
-            host: { value: '', required: true },
-            access_token: { value: '', required: false }
-        },
-        icon: "home.png",
-        label: function () { return this.name || this.url },
-        oneditprepare: function () {
-            var $hassio = $("#node-config-input-hassio");
-            var $host = $("#node-config-input-host");
-            var $legacy = $("#node-config-input-legacy");
+  RED.nodes.registerType("server", {
+    category: "config",
+    defaults: {
+      name: { value: "Home Assistant", required: false },
+      legacy: { value: false },
+      hassio: { value: false },
+      rejectUnauthorizedCerts: { value: true },
+      ha_boolean: { value: "y|yes|true|on|home|open" }
+    },
+    credentials: {
+      host: { value: "", required: true },
+      access_token: { value: "", required: false }
+    },
+    icon: "home.png",
+    label: function() {
+      return this.name || this.url;
+    },
+    oneditprepare: function() {
+      var $hassio = $("#node-config-input-hassio");
+      var $host = $("#node-config-input-host");
+      var $legacy = $("#node-config-input-legacy");
 
-            if (this.rejectUnauthorizedCerts === false) {
-                $("#accept_unauthorized_certs").prop('checked', true);
-            }
+      if (this.ha_boolean === undefined) {
+        $("#node-config-input-ha_boolean").val("y|yes|true|on|home|open");
+      }
 
-            if (!$hassio.prop("checked") && $host.val() === "http://hassio/homeassistant") {
-                $hassio.prop("checked", true);
-            }
-            function updateHassio() {
-                $("#server-info").toggle(!$hassio.prop("checked"));
-            }
-            updateHassio();
-            $hassio.on("click", function () {
-                updateHassio();
-            });
+      if (this.rejectUnauthorizedCerts === false) {
+        $("#accept_unauthorized_certs").prop("checked", true);
+      }
 
-            function updateLegacy() {
-                var tokenName = $legacy.prop("checked") ? "Password" : "Access Token";
+      if (
+        !$hassio.prop("checked") &&
+        $host.val() === "http://hassio/homeassistant"
+      ) {
+        $hassio.prop("checked", true);
+      }
+      function updateHassio() {
+        $("#server-info").toggle(!$hassio.prop("checked"));
+      }
+      updateHassio();
+      $hassio.on("click", function() {
+        updateHassio();
+      });
 
-                $("#access-token-label").html('<i class="fa fa-user-secret"></i> ' + tokenName);
-                $("#node-config-input-access_token").attr("placeholder", tokenName.toLowerCase());
-            }
-            updateLegacy();
-            $legacy.on("click", function () {
-                updateLegacy();
-            });
-        },
-        oneditsave: function () {
-            var hassio = $('#node-config-input-hassio').is(":checked");
-            var $host = $("#node-config-input-host");
-            var hostname = $host.val();
+      function updateLegacy() {
+        var tokenName = $legacy.prop("checked") ? "Password" : "Access Token";
 
-            if (hassio) {
-                $host.val('http://hassio/homeassistant');
-                this.legacy = false;
-                this.rejectUnauthorizedCerts = true;
-            } else {
-                var parser = document.createElement("a");
-                parser.href = hostname;
+        $("#access-token-label").html(
+          '<i class="fa fa-user-secret"></i> ' + tokenName
+        );
+        $("#node-config-input-access_token").attr(
+          "placeholder",
+          tokenName.toLowerCase()
+        );
+      }
+      updateLegacy();
+      $legacy.on("click", function() {
+        updateLegacy();
+      });
+    },
+    oneditsave: function() {
+      var hassio = $("#node-config-input-hassio").is(":checked");
+      var $host = $("#node-config-input-host");
+      var hostname = $host.val();
 
-                if (hostname !== parser.origin) {
-                    RED.notify("Invalid format of Base URL: " + hostname);
-                }
+      if (hassio) {
+        $host.val("http://hassio/homeassistant");
+        this.legacy = false;
+        this.rejectUnauthorizedCerts = true;
+      } else {
+        var parser = document.createElement("a");
+        parser.href = hostname;
 
-                // Save the inverse of the checkbox
-                this.rejectUnauthorizedCerts = !$('#accept_unauthorized_certs').prop('checked');
-            }
+        if (hostname !== parser.origin) {
+          RED.notify("Invalid format of Base URL: " + hostname);
         }
-    });
+
+        // Save the inverse of the checkbox
+        this.rejectUnauthorizedCerts = !$("#accept_unauthorized_certs").prop(
+          "checked"
+        );
+      }
+    }
+  });
 </script>
 
 <script type="text/x-red" data-template-name="server">
-    <div class="form-row">
-        <label for="node-config-input-name" style="width: 120px"><i class="fa fa-tag"></i> Name</label>
-        <input type="text" id="node-config-input-name" />
-    </div>
+  <div class="form-row">
+      <label for="node-config-input-name" style="width: 120px"><i class="fa fa-tag"></i> Name</label>
+      <input type="text" id="node-config-input-name" />
+  </div>
 
-    <div class="form-row">
-        <input type="checkbox" id="node-config-input-hassio" style="width: auto;margin-left: 125px;vertical-align: top" />
-        <label for="node-config-input-hassio" style="width: auto;"> I use Hass.io</label>
-    </div>
+  <div class="form-row">
+      <input type="checkbox" id="node-config-input-hassio" style="width: auto;margin-left: 125px;vertical-align: top" />
+      <label for="node-config-input-hassio" style="width: auto;"> I use Hass.io</label>
+  </div>
 
-    <div id="server-info">
-        <div class="form-row">
-            <label for="node-config-input-host" style="width: 120px"><i class="fa fa-link"></i> Base URL</label>
-            <input type="text" id="node-config-input-host" placeholder="http://localhost:8123" />
-        </div>
+  <div id="server-info">
+      <div class="form-row">
+          <label for="node-config-input-host" style="width: 120px"><i class="fa fa-link"></i> Base URL</label>
+          <input type="text" id="node-config-input-host" placeholder="http://localhost:8123" />
+      </div>
 
-        <div class="form-row">
-            <label id="access-token-label" for="node-config-input-access_token" style="width: 120px"><i class="fa fa-user-secret"></i> Access Token</label>
-            <input type="text" id="node-config-input-access_token" placeholder="access token" />
-        </div>
+      <div class="form-row">
+          <label id="access-token-label" for="node-config-input-access_token" style="width: 120px"><i class="fa fa-user-secret"></i> Access Token</label>
+          <input type="text" id="node-config-input-access_token" placeholder="access token" />
+      </div>
 
-        <div class="form-row">
-            <input type="checkbox" id="node-config-input-legacy" style="width: auto;margin-left: 125px;vertical-align: top" />
-            <label for="node-config-input-legacy" style="width: auto;"> Use Legacy API Password</label>
-        </div>
+      <div class="form-row">
+          <input type="checkbox" id="node-config-input-legacy" style="width: auto;margin-left: 125px;vertical-align: top" />
+          <label for="node-config-input-legacy" style="width: auto;"> Use Legacy API Password</label>
+      </div>
 
-        <div class="form-row">
-            <input type="checkbox" id="accept_unauthorized_certs" style="width: auto;margin-left: 125px;vertical-align: top" />
-            <label for="accept_unauthorized_certs" style="width: auto;"> Accept Unauthorized SSL Certificates</label>
-        </div>
-    </div>
+      <div class="form-row">
+          <input type="checkbox" id="accept_unauthorized_certs" style="width: auto;margin-left: 125px;vertical-align: top" />
+          <label for="accept_unauthorized_certs" style="width: auto;"> Accept Unauthorized SSL Certificates</label>
+      </div>
+  </div>
+
+  <div class="form-row">
+        <label for="node-config-input-ha_boolean" style="width: 120px"><i class="fa fa-link"></i> State Boolean</label>
+        <input type="text" id="node-config-input-ha_boolean" placeholder="y|yes|true|on|home|open" />
+  </div>
 </script>
 
 <script type="text/x-red" data-help-name="server">
@@ -107,48 +129,51 @@
 
     <h3>Config</h3>
     <dl class="message-properties">
-            <dt>Name <span class="property-type">string</span></dt>
-            <dd>Label for this configuration, see details below for implications</dd>
+        <dt>Name <span class="property-type">string</span></dt>
+        <dd>Label for this configuration, see details below for implications</dd>
 
-            <dt>Hass.io <span class="property-type">boolean</span></dt>
-            <dd>If you're connecting Hass.io check this. No other information is needed.</dd>
+        <dt>Hass.io <span class="property-type">boolean</span></dt>
+        <dd>If you're connecting Hass.io check this. No other information is needed.</dd>
 
-            <dt>Base URL <span class="property-type">string</span></dt>
-            <dd>The base url and port the home assistant instance can be reached at, for example: <code>http://192.168.0.100:8123</code> or <code>https://homeassistant.mysite.com</code></dd>
+        <dt>Base URL <span class="property-type">string</span></dt>
+        <dd>The base url and port the home assistant instance can be reached at, for example: <code>http://192.168.0.100:8123</code> or <code>https://homeassistant.mysite.com</code></dd>
 
-            <dt>Access Token / Password <span class="property-type">string</span></dt>
-            <dd>Long-lived Access Token or Password used to contact the API</dd>
+        <dt>Access Token / Password <span class="property-type">string</span></dt>
+        <dd>Long-lived Access Token or Password used to contact the API</dd>
 
-            <dt>Legacy Password <span class="property-type">boolean</span></dt>
-            <dd>If you're using the legacy password to log into Home Assistant check this and enter your password in the password text box.</dd>
+        <dt>Legacy Password <span class="property-type">boolean</span></dt>
+        <dd>If you're using the legacy password to log into Home Assistant check this and enter your password in the password text box.</dd>
 
-            <dt>Unauthorized SSL Certificates <span class="property-type">boolean</span></dt>
-            <dd>This will allow you to use self-signed certificates. Only use this if you know what you're doing.</dd>
+        <dt>Unauthorized SSL Certificates <span class="property-type">boolean</span></dt>
+        <dd>This will allow you to use self-signed certificates. Only use this if you know what you're doing.</dd>
+
+        <dt>State Boolean <span class="property-type">string | delimited</span></dt>
+        <dd>A list of strings, not case sensitive, delimited by vertial pipe, | , that will return true for State Type Boolean.</dd>
     </dl>
 
-    <h3>Details</h3>
-    <p>Every node requires a configuration attached to define how to contact home assistant, that is this config node's main purpose.</p>
+  <h3>Details</h3>
+  <p>Every node requires a configuration attached to define how to contact home assistant, that is this config node's main purpose.</p>
 
-    <h4>Context</h4>
-    <p>Each config node will also make some data available on the global context, the <code>Name</code> value in this node is used as a, camelcased, namespace for those values</p>
-    <p>Currently <code>states</code>, <code>services</code> and <code>events</code> is made available on the global context.  <code>states</code> is always set to all available states at startup and updated whenever state changes occur so it should be always up to date. <code>services</code> and <code>events</code> is only updated on initial deploy.</p>
+  <h4>Context</h4>
+  <p>Each config node will also make some data available on the global context, the <code>Name</code> value in this node is used as a, camelcased, namespace for those values</p>
+  <p>Currently <code>states</code>, <code>services</code> and <code>events</code> is made available on the global context.  <code>states</code> is always set to all available states at startup and updated whenever state changes occur so it should be always up to date. <code>services</code> and <code>events</code> is only updated on initial deploy.</p>
 
-    <h4>Context Example</h4>
-    <p>Say we have a config node with name <code>My Awesome server</code>, with an entity setup in homeassistant as <code>switch.my_switch</code>.  This state would be available within function nodes and you could fetch using something like the below code</p>
-    <p>NOTE: It's likely one of the state or trigger nodes will better serve most use cases, this is simply provided as an option for more advanced cases, or to implement functionality I haven't thought of/gotten around to</p>
+  <h4>Context Example</h4>
+  <p>Say we have a config node with name <code>My Awesome server</code>, with an entity setup in homeassistant as <code>switch.my_switch</code>.  This state would be available within function nodes and you could fetch using something like the below code</p>
+  <p>NOTE: It's likely one of the state or trigger nodes will better serve most use cases, this is simply provided as an option for more advanced cases, or to implement functionality I haven't thought of/gotten around to</p>
 
-    <pre>
-    const haCtx       = global.get('homeassistant');
-    const configCtx   = haCtx.myAwesomeServer;
-    const entityState = configCtx.states['switch.my_switch'];
-    return (entityState.state === 'on') ? true : false;
-    </pre>
+  <pre>
+  const haCtx = global.get('homeassistant');
+  const configCtx = haCtx.myAwesomeServer;
+  const entityState = configCtx.states['switch.my_switch'];
+  return (entityState.state === 'on') ? true : false;
+  </pre>
 
-    <h3>Connection Issues</h3>
-    <p>Communication with homeassistant is accomplished via a combination of WebSocket and the REST API, if you are having troubles communicating with home assistant make sure you can access the API outside of node-red, but from the same server node-red is running on, using a REST client, curl, or any number of other methods to validate the connection<p>
+  <h3>Connection Issues</h3>
+  <p>Communication with homeassistant is accomplished via a combination of WebSocket and the REST API, if you are having troubles communicating with home assistant make sure you can access the API outside of node-red, but from the same server node-red is running on, using a REST client, curl, or any number of other methods to validate the connection<p>
 
-    <h3>References</h3>
-    <ul>
-        <li><a href="https://home-assistant.io/developers/rest_api">HA REST API</a></li>
-    </ul>
+  <h3>References</h3>
+  <ul>
+      <li><a href="https://home-assistant.io/developers/rest_api">HA REST API</a></li>
+  </ul>
 </script>

--- a/nodes/config-server/config-server.js
+++ b/nodes/config-server/config-server.js
@@ -30,7 +30,8 @@ module.exports = function(RED) {
             name: {},
             legacy: {},
             hassio: {},
-            rejectUnauthorizedCerts: {}
+            rejectUnauthorizedCerts: {},
+            ha_boolean: {}
         }
     };
 

--- a/nodes/current-state/current-state.html
+++ b/nodes/current-state/current-state.html
@@ -1,159 +1,181 @@
 <script type="text/javascript">
-    RED.nodes.registerType('api-current-state', {
-        category: 'home_assistant',
-        color: '#52C0F2',
-        inputs: 1,
-        outputs: 1,
-        icon: "arrow-top-right.png",
-        paletteLabel: 'current state',
-        label: function () { return this.name || `current_state: ${this.entity_id}`; },
-        defaults: {
-            name: { value: '' },
-            server: { value: '', type: 'server', required: true },
-            halt_if: { value: '' },
-            override_topic: { value: true },
-            override_payload: { value: true },
-            override_data: { value: true },
-            entity_id: { value: '' },
-        },
-        oneditprepare: function () {
-            const $entityIdField = $('#entity_id');
-            $entityIdField.val(this.entity_id);
+  RED.nodes.registerType("api-current-state", {
+    category: "home_assistant",
+    color: "#52C0F2",
+    inputs: 1,
+    outputs: 1,
+    icon: "arrow-top-right.png",
+    paletteLabel: "current state",
+    label: function() {
+      return this.name || `current_state: ${this.entity_id}`;
+    },
+    defaults: {
+      name: { value: "" },
+      server: { value: "", type: "server", required: true },
+      halt_if: { value: "" },
+      override_topic: { value: true },
+      override_payload: { value: true },
+      override_data: { value: true },
+      entity_id: { value: "" },
+      state_type: { value: "str" }
+    },
+    oneditprepare: function() {
+      const $entityIdField = $("#entity_id");
+      $entityIdField.val(this.entity_id);
 
-            const NODE = this;
-            const $server = $('#node-input-server');
-            const utils = {
-                setDefaultServerSelection: function () {
-                    let defaultServer;
-                    RED.nodes.eachConfig(n => {
-                        if (n.type === 'server' && !defaultServer) defaultServer = n.id;
-                    });
-                    if (defaultServer) $server.val(defaultServer);
-                }
-            };
-
-            if (!NODE.server) {
-                utils.setDefaultServerSelection();
-            }
-
-            // Check that proper config is set
-            const config = RED.nodes.node($('#node-input-server').val());
-            const isConfigValid = (config && config.valid);
-            // TODO: Doesn't seem to be working
-            if (!isConfigValid) { $entityIdField.addClass('disabled'); }
-            else { $entityIdField.removeClass('disabled'); }
-
-            const selectedServer = $server.val();
-            if (NODE.server || (selectedServer && selectedServer !== '_ADD_')) {
-                $.get(`homeassistant/entities`)
-                    .done((entities) => {
-                        this.availableEntities = JSON.parse(entities);
-
-                        $entityIdField.autocomplete({
-                            source: this.availableEntities,
-                            minLength: 0,
-                            change: (evt, ui) => {
-                                const validSelection = (this.availableEntities.indexOf($(evt.target).val()) > -1);
-                                if (validSelection) { $(evt.target).removeClass('input-error'); }
-                                else { $(evt.target).addClass('input-error'); }
-                            }
-                        });
-
-                        const validSelection = (this.availableEntities.indexOf(this.entity_id) > -1);
-                        if (validSelection) { $entityIdField.removeClass('input-error'); }
-                        else { $entityIdField.addClass('input-error'); }
-                    })
-                    .fail((err) => RED.notify(err.responseText, 'error'));
-            }
-        },
-        oneditsave: function () {
-            this.entity_id = $("#entity_id").val();
+      const NODE = this;
+      const $server = $("#node-input-server");
+      const utils = {
+        setDefaultServerSelection: function() {
+          let defaultServer;
+          RED.nodes.eachConfig(n => {
+            if (n.type === "server" && !defaultServer) defaultServer = n.id;
+          });
+          if (defaultServer) $server.val(defaultServer);
         }
-    });
+      };
+
+      if (!NODE.server) {
+        utils.setDefaultServerSelection();
+      }
+
+      // Check that proper config is set
+      const config = RED.nodes.node($("#node-input-server").val());
+      const isConfigValid = config && config.valid;
+      // TODO: Doesn't seem to be working
+      if (!isConfigValid) {
+        $entityIdField.addClass("disabled");
+      } else {
+        $entityIdField.removeClass("disabled");
+      }
+
+      const selectedServer = $server.val();
+      if (NODE.server || (selectedServer && selectedServer !== "_ADD_")) {
+        $.get(`homeassistant/entities`)
+          .done(entities => {
+            this.availableEntities = JSON.parse(entities);
+
+            $entityIdField.autocomplete({
+              source: this.availableEntities,
+              minLength: 0,
+              change: (evt, ui) => {
+                const validSelection =
+                  this.availableEntities.indexOf($(evt.target).val()) > -1;
+              }
+            });
+
+            const validSelection =
+              this.availableEntities.indexOf(this.entity_id) > -1;
+          })
+          .fail(err => RED.notify(err.responseText, "error"));
+      }
+    },
+    oneditsave: function() {
+      this.entity_id = $("#entity_id").val();
+    }
+  });
 </script>
 
 <script type="text/x-red" data-template-name="api-current-state">
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
-        <input type="text" id="node-input-name" placeholder="Name">
-    </div>
+  <div class="form-row">
+      <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+      <input type="text" id="node-input-name" placeholder="Name">
+  </div>
 
-    <div class="form-row">
-        <label for="node-input-server"><i class="fa fa-server"></i> Server</label>
-        <input type="text" id="node-input-server" />
-    </div>
+  <div class="form-row">
+      <label for="node-input-server"><i class="fa fa-server"></i> Server</label>
+      <input type="text" id="node-input-server" />
+  </div>
 
-    <div class="form-row">
-        <label for="entity_id"><i class="fa fa-cube"></i> Entity ID</label>
-        <input type="text" id="entity_id">
-    </div>
+  <div class="form-row">
+      <label for="entity_id"><i class="fa fa-cube"></i> Entity ID</label>
+      <input type="text" id="entity_id">
+  </div>
 
-    <div class="form-row">
-        <label for="node-input-override_topic">&nbsp;</label>
-        <input type="checkbox" id="node-input-override_topic" checked style="display:inline-block; width:15px; vertical-align:baseline;">&nbsp;
-        <span>Override Topic</span>
-    </div>
+  <div class="form-row">
+      <label for="node-input-halt_if"><i class="fa fa-hand-paper-o"></i> Halt If</label>
+      <input type="text" id="node-input-halt_if" placeholder="off" />
+  </div>
 
-    <div class="form-row">
-        <label for="node-input-override_payload">&nbsp;</label>
-        <input type="checkbox" id="node-input-override_payload" checked style="display:inline-block; width:15px; vertical-align:baseline;">&nbsp;
-        <span>Override Payload</span>
-    </div>
+  <div class="form-row">
+      <label for="node-input-state_type"><i class="fa fa-tint"></i> State Type</label>
+      <select type="text" id="node-input-state_type" style="width: auto;">
+          <option value="str">String</option>
+          <option value="num">Number</option>
+          <option value="habool">Boolean</option>
+      </select>
+  </div>
 
-    <div class="form-row">
-        <label for="node-input-override_data">&nbsp;</label>
-        <input type="checkbox" id="node-input-override_data" checked style="display:inline-block; width:15px; vertical-align:baseline;">&nbsp;
-        <span>Override Data</span>
-    </div>
+  <div class="form-row">
+      <span style="width: 100px;display: inline-block;">Override</span>
 
-    <div class="form-row">
-        <label for="node-input-halt_if"><i class="fa fa-hand-paper-o"></i> Halt If</label>
-        <input type="text" id="node-input-halt_if" placeholder="off" />
-    </div>
+      <input type="checkbox" id="node-input-override_topic" checked style="display:inline-block; width:15px; vertical-align:baseline;">&nbsp;
+      <label for="node-input-override_topic" style="width: auto;margin-right: 20px;">Topic</label>
 
+      <input type="checkbox" id="node-input-override_payload" checked style="display:inline-block; width:15px; vertical-align:baseline;">&nbsp;
+      <label for="node-input-override_payload" style="width: auto;margin-right: 20px;">Payload</label>
+
+      <input type="checkbox" id="node-input-override_data" checked style="display:inline-block; width:15px; vertical-align:baseline;">&nbsp;
+      <label for="node-input-override_data" style="width: auto;">Data</label>
+  </div>
 </script>
 
 <script type="text/x-red" data-help-name="api-current-state">
-    <p>Get the current state of an Entity</p>
+  <p>Get the current state of an Entity</p>
 
-    <h3>Inputs</h3>
-        <dl class="message-properties">
-            <dt class="optional">payload.entity_id <span class="property-type">string</span> </dt>
-            <dd> Overrides or sets the entity_id for which the current state is being fetched </dd>
-        </dl>
+  <h3>Inputs</h3>
+  <dl class="message-properties">
+      <dt class="optional">payload.entity_id <span class="property-type">string</span> </dt>
+      <dd> Overrides or sets the entity_id for which the current state is being fetched </dd>
+  </dl>
 
-    <h3>Outputs</h3>
-        <dl class="message-properties">
-            <dt>topic (same as data.entity_id)<span class="property-type">string</span></dt>
-            <dd>Latest current state object received from home assistant</dd>
+  <h3>Configuration</h3>
+  <dl class="message-properties">
+      <dt>Entity ID<span class="property-type">string</span></dt>
+      <dd>Match for entity_id field</dd>
 
-            <dt>payload (same as data.state)<span class="property-type">string</span></dt>
-            <dd>Latest current state object received from home assistant</dd>
+      <dt>Half If<span class="property-type">string</span></dt>
+      <dd>If the new_state === this setting then skip sending</dd>
 
-            <dt>data <span class="property-type">object</span></dt>
-            <dd>Latest current state object received from home assistant</dd>
+      <dt>State Type<span class="property-type">string</span></dt>
+      <dd>Convert the state of the entity to the selected type. Boolean will be convert to true based on if the string is equial by default to (y|yes|true|on|home|open). Original value stored in msg.data.original_state</dd>
 
-            <dt>data.state <span class="property-type">string</span></dt>
-            <dd>Main attribute state value, examples: 'on', 'off', 'home', 'open', 'closed', etc...</dd>
+      <dt>Overrides<span class="property-type">boolean</span></dt>
+      <dd></dd>
+  </dl>
 
-            <dt>data.entity_id <span class="property-type">string</span></dt>
-            <dd>The entity to which this state belongs</dd>
+  <h3>Outputs</h3>
+  <dl class="message-properties">
+      <dt>topic (same as data.entity_id)<span class="property-type">string</span></dt>
+      <dd>Latest current state object received from home assistant</dd>
 
-            <dt>data.attributes <span class="property-type">object</span></dt>
-            <dd>Supported attributes of state set by homeassistant</dd>
+      <dt>payload (same as data.state)<span class="property-type">string</span></dt>
+      <dd>Latest current state object received from home assistant</dd>
 
-            <dt>data.last_changed <span class="property-type">string</span></dt>
-            <dd>ISO Date string of last time entity state changed</dd>
+      <dt>data <span class="property-type">object</span></dt>
+      <dd>Latest current state object received from home assistant</dd>
 
-            <dt>data.last_updated <span class="property-type">string</span></dt>
-            <dd>ISO Date string of last time entity state was updated</dd>
-        </dl>
+      <dt>data.state <span class="property-type">string</span></dt>
+      <dd>Main attribute state value, examples: 'on', 'off', 'home', 'open', 'closed', etc...</dd>
 
-    <h3>Details</h3>
-        <p>Returns the current state of an entity. Useful for using as conditional logic to automation flows.</p>
+      <dt>data.entity_id <span class="property-type">string</span></dt>
+      <dd>The entity to which this state belongs</dd>
 
-    <h3>References</h3>
-        <ul>
-            <li><a href="https://home-assistant.io/docs/configuration/state_object/">Home Assistant State Objects</a></li>
-        </ul>
+      <dt>data.attributes <span class="property-type">object</span></dt>
+      <dd>Supported attributes of state set by homeassistant</dd>
+
+      <dt>data.last_changed <span class="property-type">string</span></dt>
+      <dd>ISO Date string of last time entity state changed</dd>
+
+      <dt>data.last_updated <span class="property-type">string</span></dt>
+      <dd>ISO Date string of last time entity state was updated</dd>
+  </dl>
+
+  <h3>Details</h3>
+      <p>Returns the current state of an entity. Useful for using as conditional logic to automation flows.</p>
+
+  <h3>References</h3>
+      <ul>
+          <li><a href="https://home-assistant.io/docs/configuration/state_object/">Home Assistant State Objects</a></li>
+      </ul>
 </script>

--- a/nodes/events-state-changed/events-state-changed.html
+++ b/nodes/events-state-changed/events-state-changed.html
@@ -1,125 +1,146 @@
 <script type="text/javascript">
-    RED.nodes.registerType('server-state-changed', {
-        category: 'home_assistant',
-        color: '#038FC7',
-        defaults: {
-            name: { value: '' },
-            server: { value: '', type: 'server', required: true },
-            entityidfilter: { value: '', required: true },
-            entityidfiltertype: { value: 'substring' },
-            haltifstate: { value: '' },
-            outputinitially: { value: false }
-        },
-        inputs: 0,
-        outputs: 1,
-        icon: "arrow-right-bold-hexagon-outline.png",
-        paletteLabel: 'events: state',
-        label: function () { return this.name || `state_changed: ${this.entityidfilter || 'all entities'}` },
-        oneditprepare: function () {
-            const $entityidfilter = $('#node-input-entityidfilter');
-            const $entityidfiltertype = $('#node-input-entityidfiltertype');
-            const $server = $('#node-input-server');
+  RED.nodes.registerType("server-state-changed", {
+    category: "home_assistant",
+    color: "#038FC7",
+    defaults: {
+      name: { value: "" },
+      server: { value: "", type: "server", required: true },
+      entityidfilter: { value: "", required: true },
+      entityidfiltertype: { value: "substring" },
+      haltifstate: { value: "" },
+      outputinitially: { value: false },
+      state_type: { value: "str" }
+    },
+    inputs: 0,
+    outputs: 1,
+    icon: "arrow-right-bold-hexagon-outline.png",
+    paletteLabel: "events: state",
+    label: function() {
+      return (
+        this.name || `state_changed: ${this.entityidfilter || "all entities"}`
+      );
+    },
+    oneditprepare: function() {
+      const $entityidfilter = $("#node-input-entityidfilter");
+      const $entityidfiltertype = $("#node-input-entityidfiltertype");
+      const $server = $("#node-input-server");
 
-            $entityidfilter.val(this.entityidfilter);
-            this.entityidfiltertype = this.entityidfiltertype || 'substring';
-            $entityidfiltertype.val(this.entityidfiltertype);
+      $entityidfilter.val(this.entityidfilter);
+      this.entityidfiltertype = this.entityidfiltertype || "substring";
+      $entityidfiltertype.val(this.entityidfiltertype);
 
-            const NODE = this;
-            const utils = {
-                setDefaultServerSelection: function () {
-                    let defaultServer;
-                    RED.nodes.eachConfig(n => {
-                        if (n.type === 'server' && !defaultServer) defaultServer = n.id;
-                    });
-                    if (defaultServer) $server.val(defaultServer);
-                }
-            };
-
-            if (!NODE.server) {
-                utils.setDefaultServerSelection();
-            }
-
-            const setupAutocomplete = (node) => {
-                const selectedServer = $server.val();
-
-                // A home assistant server is selected in the node config
-                if (node.server || (selectedServer && selectedServer !== '_ADD_')) {
-                    $.get(`homeassistant/entities`).done((entities) => {
-                        node.availableEntities = JSON.parse(entities);
-                        $entityidfilter.autocomplete({ source: node.availableEntities, minLength: 0 });
-                    })
-                        .fail((err) => RED.notify(err.responseText, 'error'));
-                }
-            };
-
-            $server.change(() => setupAutocomplete(this));
-        },
-        oneditsave: function () {
-            this.entityidfilter = $("#node-input-entityidfilter").val();
+      const NODE = this;
+      const utils = {
+        setDefaultServerSelection: function() {
+          let defaultServer;
+          RED.nodes.eachConfig(n => {
+            if (n.type === "server" && !defaultServer) defaultServer = n.id;
+          });
+          if (defaultServer) $server.val(defaultServer);
         }
-    });
+      };
+
+      if (!NODE.server) {
+        utils.setDefaultServerSelection();
+      }
+
+      const setupAutocomplete = node => {
+        const selectedServer = $server.val();
+
+        // A home assistant server is selected in the node config
+        if (node.server || (selectedServer && selectedServer !== "_ADD_")) {
+          $.get(`homeassistant/entities`)
+            .done(entities => {
+              node.availableEntities = JSON.parse(entities);
+              $entityidfilter.autocomplete({
+                source: node.availableEntities,
+                minLength: 0
+              });
+            })
+            .fail(err => RED.notify(err.responseText, "error"));
+        }
+      };
+
+      $server.change(() => setupAutocomplete(this));
+    },
+    oneditsave: function() {
+      this.entityidfilter = $("#node-input-entityidfilter").val();
+    }
+  });
 </script>
 
-
 <script type="text/x-red" data-template-name="server-state-changed">
-    <!-- Name -->
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
-        <input type="text" id="node-input-name" placeholder="Name">
-    </div>
+  <!-- Name -->
+  <div class="form-row">
+      <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+      <input type="text" id="node-input-name" placeholder="Name">
+  </div>
 
-    <!-- Server -->
-    <div class="form-row">
-        <label for="node-input-server"><i class="fa fa-server"></i> Server</label>
-        <input type="text" id="node-input-server" />
-    </div>
+  <!-- Server -->
+  <div class="form-row">
+      <label for="node-input-server"><i class="fa fa-server"></i> Server</label>
+      <input type="text" id="node-input-server" />
+  </div>
 
-    <!-- Entity ID Filter and Filter Type -->
-    <div class="form-row">
-        <label for="node-input-entityidfilter"><i class="fa fa-tag"></i> Entity ID</label>
+  <!-- Entity ID Filter and Filter Type -->
+  <div class="form-row">
+      <label for="node-input-entityidfilter"><i class="fa fa-tag"></i> Entity ID</label>
 
-        <input type="text" id="node-input-entityidfilter" placeholder="binary_sensor" style="width: 50%;" />
+      <input type="text" id="node-input-entityidfilter" placeholder="binary_sensor" style="width: 50%;" />
 
-        <select type="text" id="node-input-entityidfiltertype" style="width: 20%;">
-            <option value="exact">Exact</option>
-            <option value="substring">Substring</option>
-            <option value="regex">Regex</option>
-        </select>
-    </div>
+      <select type="text" id="node-input-entityidfiltertype" style="width: 20%;">
+          <option value="exact">Exact</option>
+          <option value="substring">Substring</option>
+          <option value="regex">Regex</option>
+      </select>
+  </div>
 
-    <div class="form-row">
-        <label for="node-input-haltifstate"><i class="fa fa-hand-paper-o"></i> Halt If State</label>
-        <input type="text" id="node-input-haltifstate" />
-    </div>
+  <div class="form-row">
+      <label for="node-input-haltifstate"><i class="fa fa-hand-paper-o"></i> Halt If State</label>
+      <input type="text" id="node-input-haltifstate" />
+  </div>
 
-    <div class="form-row">
-        <input type="checkbox" id="node-input-outputinitially" style="display: inline-block; width: auto; vertical-align: top;">
-        <label for="node-input-outputinitially" style="width: auto;">Output Initially / On Deploy</label>
-    </div>
+  <div class="form-row">
+      <label for="node-input-state_type"><i class="fa fa-tint"></i> State Type</label>
+      <select type="text" id="node-input-state_type" style="width: auto;">
+          <option value="str">String</option>
+          <option value="num">Number</option>
+          <option value="habool">Boolean</option>
+      </select>
+  </div>
+
+  <div class="form-row">
+      <input type="checkbox" id="node-input-outputinitially" style="display: inline-block; width: auto; vertical-align: top;margin-left: 105px;">
+      <label for="node-input-outputinitially" style="width: auto;">Output Initially / On Deploy</label>
+  </div>
 </script>
 
 <script type="text/x-red" data-help-name="server-state-changed">
-    <p class="ha-description">Outputs 'state_changed' event types sent from Home Assistant</p>
+  <p class="ha-description">Outputs 'state_changed' event types sent from Home Assistant</p>
 
-    <p class="ha-subdescription">The autocomplete will open to allow easier selection in the case you want a specific entity however the actual match is a substring match so no validation is done</p>
-    <p class="ha-additional-info">NOTE: You can add multiple string matches by comma separated list and each entry will be matched separately</p>
+  <p class="ha-subdescription">The autocomplete will open to allow easier selection in the case you want a specific entity however the actual match is a substring match so no validation is done</p>
 
-    <h4 class="ha-title">Configuration:</h4>
-    <table class="ha-table" style="width: 100%;" border="1" cellpadding="10">
-        <tbody>
-            <tr> <td>Entity ID Filter</td>      <td>CSV substring matches for entity_id field</td>      </tr>
-            <tr> <td>Halt If State</td>         <td>If the new_state === this setting then skip sending </tr>
-        </tbody>
-    </table>
+  <h3>Configuration:</h3>
+  <dl class="message-properties">
+      <dt>Entity ID<span class="property-type">string|regex</span></dt>
+      <dd>matches for entity_id field</dd>
 
-    <br/>
+      <dt>Halt If State<span class="property-type">string</span></dt>
+      <dd>If the new_state === this setting then skip sending</dd>
 
-    <h4 class="ha-title">Output Object:</h4>
-    <table class="ha-table" style="width: 100%;" border="1" cellpadding="10">
-        <tbody>
-            <tr> <td>topic</td>      <td>entity_id (e.g.: sensor.bedroom_temp)</td>                                 </tr>
-            <tr> <td>payload</td>    <td>event.new_state.state (e.g.: 'on', 'off', '88.5', 'home', 'not_home')</td> </tr>
-            <tr> <td>data</td>       <td>original event object from homeassistant</td> </tr>
-        </tbody>
-    </table>
+      <dt>State Type<span class="property-type">string</span></dt>
+      <dd>Convert the state of the entity to the selected type. Boolean will be convert to true based on if the string is equial by default to (y|yes|true|on|home|open). Original value stored in msg.data.original_state</dd>
+  </dl>
+
+  <h3>Output Object:</h3>
+  <dl class="message-properties">
+      <dt>topic<span class="property-type">string</span></dt>
+      <dd>CSV substring matches for entity_id field</dd>
+
+      <dt>payload<span class="property-type">string|number|boolean</span></dt>
+      <dd>event.new_state.state (e.g.: 'on', 'off', 88.5, 'home', 'not_home')</dd>
+
+      <dt>data<span class="property-type">json</span></dt>
+      <dd>original event object from homeassistant</dd>
+  </dl>
 </script>

--- a/nodes/poll-state/poll-state.html
+++ b/nodes/poll-state/poll-state.html
@@ -1,144 +1,170 @@
 <script type="text/javascript">
-    RED.nodes.registerType('poll-state', {
-        category: 'home_assistant',
-        color: '#038FC7',
-        inputs: 0,
-        outputs: 1,
-        icon: 'timer.png',
-        paletteLabel: 'poll state',
-        label: function () { return this.name || `poll state: ${this.entity_id}`; },
-        defaults: {
-            name: { value: '' },
-            server: { value: '', type: 'server', required: true },
-            updateinterval: { value: '', validate: (v) => !isNaN(v) },
-            outputinitially: { value: false },
-            outputonchanged: { value: false },
-            entity_id: {
-                value: '',
-                required: true
-            }
-        },
-        oneditprepare: function () {
-            const $entityIdField = $('#entity_id');
-            $entityIdField.val(this.entity_id);
+  RED.nodes.registerType("poll-state", {
+    category: "home_assistant",
+    color: "#038FC7",
+    inputs: 0,
+    outputs: 1,
+    icon: "timer.png",
+    paletteLabel: "poll state",
+    label: function() {
+      return this.name || `poll state: ${this.entity_id}`;
+    },
+    defaults: {
+      name: { value: "" },
+      server: { value: "", type: "server", required: true },
+      updateinterval: { value: "", validate: v => !isNaN(v) },
+      outputinitially: { value: false },
+      outputonchanged: { value: false },
+      entity_id: {
+        value: "",
+        required: true
+      },
+      state_type: { value: "str" }
+    },
+    oneditprepare: function() {
+      const $entityIdField = $("#entity_id");
+      $entityIdField.val(this.entity_id);
 
-            const NODE = this;
-            const $server = $('#node-input-server');
-            const utils = {
-                setDefaultServerSelection: function () {
-                    let defaultServer;
-                    RED.nodes.eachConfig(n => {
-                        if (n.type === 'server' && !defaultServer) defaultServer = n.id;
-                    });
-                    if (defaultServer) $server.val(defaultServer);
+      const NODE = this;
+      const $server = $("#node-input-server");
+      const utils = {
+        setDefaultServerSelection: function() {
+          let defaultServer;
+          RED.nodes.eachConfig(n => {
+            if (n.type === "server" && !defaultServer) defaultServer = n.id;
+          });
+          if (defaultServer) $server.val(defaultServer);
+        }
+      };
+
+      if (!NODE.server) {
+        utils.setDefaultServerSelection();
+      }
+
+      // Check that proper config is set
+      const config = RED.nodes.node($("#node-input-server").val());
+      const isConfigValid = config && config.valid;
+      // TODO: Doesn't seem to be working
+      if (!isConfigValid) {
+        $entityIdField.addClass("disabled");
+      } else {
+        $entityIdField.removeClass("disabled");
+      }
+
+      const selectedServer = $server.val();
+      if (NODE.server || (selectedServer && selectedServer !== "_ADD_")) {
+        $.get(`homeassistant/entities`)
+          .done(entities => {
+            this.availableEntities = JSON.parse(entities);
+
+            $entityIdField.autocomplete({
+              source: this.availableEntities,
+              minLength: 0,
+              change: (evt, ui) => {
+                const validSelection =
+                  this.availableEntities.indexOf($(evt.target).val()) > -1;
+                if (validSelection) {
+                  $(evt.target).removeClass("input-error");
+                } else {
+                  $(evt.target).addClass("input-error");
                 }
-            };
+              }
+            });
 
-            if (!NODE.server) {
-                utils.setDefaultServerSelection();
+            const validSelection =
+              this.availableEntities.indexOf(this.entity_id) > -1;
+            if (validSelection) {
+              $entityIdField.removeClass("input-error");
+            } else {
+              $entityIdField.addClass("input-error");
             }
-
-            // Check that proper config is set
-            const config = RED.nodes.node($('#node-input-server').val());
-            const isConfigValid = (config && config.valid);
-            // TODO: Doesn't seem to be working
-            if (!isConfigValid) { $entityIdField.addClass('disabled'); }
-            else { $entityIdField.removeClass('disabled'); }
-
-            const selectedServer = $server.val();
-            if (NODE.server || (selectedServer && selectedServer !== '_ADD_')) {
-                $.get(`homeassistant/entities`)
-                    .done((entities) => {
-                        this.availableEntities = JSON.parse(entities);
-
-                        $entityIdField.autocomplete({
-                            source: this.availableEntities,
-                            minLength: 0,
-                            change: (evt, ui) => {
-                                const validSelection = (this.availableEntities.indexOf($(evt.target).val()) > -1);
-                                if (validSelection) { $(evt.target).removeClass('input-error'); }
-                                else { $(evt.target).addClass('input-error'); }
-                            }
-                        });
-
-                        const validSelection = (this.availableEntities.indexOf(this.entity_id) > -1);
-                        if (validSelection) { $entityIdField.removeClass('input-error'); }
-                        else { $entityIdField.addClass('input-error'); }
-                    })
-                    .fail((err) => RED.notify(err.responseText, 'error'));
-            }
-        },
-        oneditsave: function () { this.entity_id = $("#entity_id").val(); }
-    });
+          })
+          .fail(err => RED.notify(err.responseText, "error"));
+      }
+    },
+    oneditsave: function() {
+      this.entity_id = $("#entity_id").val();
+    }
+  });
 </script>
 
 <script type="text/x-red" data-template-name="poll-state">
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
-        <input type="text" id="node-input-name" placeholder="Name">
-    </div>
+  <div class="form-row">
+      <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+      <input type="text" id="node-input-name" placeholder="Name">
+  </div>
 
-    <div class="form-row">
-        <label for="node-input-server"><i class="fa fa-server"></i> Server</label>
-        <input type="text" id="node-input-server" />
-    </div>
+  <div class="form-row">
+      <label for="node-input-server"><i class="fa fa-server"></i> Server</label>
+      <input type="text" id="node-input-server" />
+  </div>
 
-    <div class="form-row">
-        <label for="entity_id"><i class="fa fa-cube"></i> Entity ID</label>
-        <input type="text" id="entity_id">
-    </div>
+  <div class="form-row">
+      <label for="entity_id"><i class="fa fa-cube"></i> Entity ID</label>
+      <input type="text" id="entity_id">
+  </div>
 
-    <div class="form-row">
-        <label for="node-input-updateinterval"><i class="fa fa-hand-paper-o"></i> Update Interval</label>
-        <input type="text" id="node-input-updateinterval" placeholder="10"/>
-    </div>
+  <div class="form-row">
+      <label for="node-input-updateinterval"><i class="fa fa-hand-paper-o"></i> Update Interval</label>
+      <input type="text" id="node-input-updateinterval" placeholder="10"/>
+  </div>
 
-    <div class="form-row">
-        <input type="checkbox" id="node-input-outputonchanged" style="display: inline-block; width: auto; vertical-align: top;">
-        <label for="node-input-outputonchanged" style="width: auto;">Output on Changed</label>
-    </div>
+  <div class="form-row">
+      <label for="node-input-state_type"><i class="fa fa-tint"></i> State Type</label>
+      <select type="text" id="node-input-state_type" style="width: auto;">
+          <option value="str">String</option>
+          <option value="num">Number</option>
+          <option value="habool">Boolean</option>
+      </select>
+  </div>
 
-    <div class="form-row">
-        <input type="checkbox" id="node-input-outputinitially" style="display: inline-block; width: auto; vertical-align: top;">
-        <label for="node-input-outputinitially" style="width: auto;">Output Initially / On Deploy</label>
-    </div>
+  <div class="form-row">
+      <input type="checkbox" id="node-input-outputonchanged" style="display: inline-block; width: auto; vertical-align: top;margin-left: 105px;">
+      <label for="node-input-outputonchanged" style="width: auto;">Output on Changed</label>
+  </div>
+
+  <div class="form-row">
+      <input type="checkbox" id="node-input-outputinitially" style="display: inline-block; width: auto; vertical-align: top;margin-left: 105px;">
+      <label for="node-input-outputinitially" style="width: auto;">Output Initially / On Deploy</label>
+  </div>
 </script>
 
 <script type="text/x-red" data-help-name="poll-state">
-    <p>Polls for state of given entity and outputs time since last changed</p>
+  <p>Polls for state of given entity and outputs time since last changed</p>
 
-    <h3>Config</h3>
-        <dl class="message-properties">
-                <dt>Update Interval<span class="property-type">number</span></dt>
-                <dd>Number of seconds between checking / sending updates</dd>
-                <dt>Output Initially<span class="property-type">boolean</span></dt>
-                <dd>Output once on startup/deploy then on each interval</dd>
-        </dl>
+  <h3>Config</h3>
+  <dl class="message-properties">
+    <dt>Update Interval<span class="property-type">number</span></dt>
+    <dd>Number of seconds between checking / sending updates</dd>
 
-    <h3>Outputs</h3>
-        <dl class="message-properties">
-            <dt>topic<span class="property-type">string</span></dt>
-            <dd>entity_id of changed entity</dd>
+    <dt>State Type<span class="property-type">string</span></dt>
+    <dd>Convert the state of the entity to the selected type. Boolean will be convert to true based on if the string is equial by default to (y|yes|true|on|home|open). Original value stored in msg.data.original_state</dd>
 
-            <dt>payload.timeSinceChanged<span class="property-type">string</span></dt>
-            <dd>Human readable format string of time since last updated, example "1 hour ago"</dd>
+    <dt>Output Initially<span class="property-type">boolean</span></dt>
+    <dd>Output once on startup/deploy then on each interval</dd>
+  </dl>
 
-            <dt>payload.timeSinceChangedMs<span class="property-type">number</span></dt>
-            <dd>Number of milliseconds since last changed</dd>
+  <h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>topic<span class="property-type">string</span></dt>
+    <dd>entity_id of changed entity</dd>
 
-            <dt>payload.dateChanged<span class="property-type">string</span></dt>
-            <dd>ISO date string of the date when the entity last changed</dd>
+    <dt>payload.data<span class="property-type">object</span></dt>
+    <dd>The last known state of the entity</dd>
 
-            <dt>payload.data<span class="property-type">object</span></dt>
-            <dd>The last known state of the entity</dd>
-        </dl>
+    <dt>payload.data.timeSinceChanged<span class="property-type">string</span></dt>
+    <dd>Human readable format string of time since last updated, example "1 hour ago"</dd>
 
-    <h3>Details</h3>
-        <p>Polls for state at regular intervals, optionally also outputing at start and when state changes. Useful for either alerts for non-communicating devices (time since change > 1 day for example) or dashboard graphs with consistent interval charts</p>
-        <p>NOTE: The last changed calculation is based on homeassistant's <code>last_changed</code> property so anything that changes that field will result in your last changed time outputted here to be changed.</p>
+    <dt>payload.data.timeSinceChangedMs<span class="property-type">number</span></dt>
+    <dd>Number of milliseconds since last changed</dd>
+  </dl>
 
-    <h3>References</h3>
-        <ul>
-            <li><a href="https://home-assistant.io/docs/configuration/state_object/">HA State Objects</a></li>
-        </ul>
+  <h3>Details</h3>
+  <p>Polls for state at regular intervals, optionally also outputing at start and when state changes. Useful for either alerts for non-communicating devices (time since change > 1 day for example) or dashboard graphs with consistent interval charts</p>
+  <p>NOTE: The last changed calculation is based on homeassistant's <code>last_changed</code> property so anything that changes that field will result in your last changed time outputted here to be changed.</p>
+
+  <h3>References</h3>
+  <ul>
+      <li><a href="https://home-assistant.io/docs/configuration/state_object/">HA State Objects</a></li>
+  </ul>
 </script>

--- a/nodes/trigger-state/trigger-state.html
+++ b/nodes/trigger-state/trigger-state.html
@@ -12,7 +12,8 @@
       constraintsmustmatch: { value: "all" },
       outputs: { value: 2 },
       customoutputs: { value: [] },
-      outputinitially: { value: false }
+      outputinitially: { value: false },
+      state_type: { value: "str" }
     },
     inputs: 1,
     outputs: 2,
@@ -444,6 +445,15 @@
           <option value="substring">Substring</option>
           <option value="regex">Regex</option>
         </select>
+  </div>
+
+  <div class="form-row">
+      <label for="node-input-state_type"><i class="fa fa-tint"></i> State Type</label>
+      <select type="text" id="node-input-state_type" style="width: auto;">
+          <option value="str">String</option>
+          <option value="num">Number</option>
+          <option value="habool">Boolean</option>
+      </select>
   </div>
 
   <!-- -------------------------------------------------------------- -->


### PR DESCRIPTION
- works for current-state, poll-state, event-state, and trigger-state nodes
- For the boolean state, it returns true off a regex string configurable in the server config
- the default list is /y|yes|true|on|home|open/

Both the payload and event entity states are changed with the original state value being saved in `original_state`, `msg.data.event.new_state.original_state`, where applicable.