### PR TITLE
Fix call to non-existent endpoint

### DIFF
--- a/nodes/get-history/get-history.html
+++ b/nodes/get-history/get-history.html
@@ -46,7 +46,7 @@
 
             const selectedServer = $server.val();
             if (NODE.server || (selectedServer && selectedServer !== '_ADD_')) {
-                $.get(`homeassistant/entities`)
+                $.get(`homeassistant/${selectedServer}/entities`)
                     .done((entities) => {
                         this.availableEntities = JSON.parse(entities);
 


### PR DESCRIPTION
There is no `homeassistant/entities` endpoint exposed - existing one
contains the server ID.

This broke autocomplete for entity IDs.