### PR TITLE
Correct possessive apostrophe in trigger state node constraint list

### DIFF
--- a/nodes/trigger-state/trigger-state.html
+++ b/nodes/trigger-state/trigger-state.html
@@ -174,7 +174,7 @@
 
           const entityText =
             targetType === "this_entity"
-              ? "<strong>This entities</strong>"
+              ? "<strong>This entity's</strong>"
               : `Entity ID <strong>${targetValue}</strong>`;
           const propertyText =
             propertyType === "property"

--- a/nodes/trigger-state/trigger-state.html
+++ b/nodes/trigger-state/trigger-state.html
@@ -174,7 +174,7 @@
 
           const entityText =
             targetType === "this_entity"
-              ? "<strong>This entity's</strong>"
+              ? "<strong>This entity&#8217;s</strong>"
               : `Entity ID <strong>${targetValue}</strong>`;
           const propertyText =
             propertyType === "property"


### PR DESCRIPTION
Currently, the constraint list in a trigger-state node looks like this:

![image](https://user-images.githubusercontent.com/4309984/50457096-ed869580-09bd-11e9-95b7-09f9084cd87e.png)

This PR changes corrects **entities** (plural) to be **entity's** (possessive):

![image](https://user-images.githubusercontent.com/4309984/50457141-51a95980-09be-11e9-8a65-9a46aab83726.png)

PS: I couldn't find the `dev-master` branch as suggested in the contributing guidelines. So I have PR'd into `master`.