### PR TITLE
Updated 'Halt If State' labels to mention that it halts

### DIFF
--- a/nodes/current-state/current-state.html
+++ b/nodes/current-state/current-state.html
@@ -157,7 +157,7 @@
   </div>
 
   <div class="form-row">
-    <label for="node-input-halt_if_compare"><i class="fa fa-random"></i> If State</label>
+    <label for="node-input-halt_if_compare"><i class="fa fa-random"></i> Halt If State</label>
     <div style="width: 70%;display: inline-block;">
       <select type="text" id="node-input-halt_if_compare" style="width: auto;">
         <option value="is">is</option>

--- a/nodes/events-state-changed/events-state-changed.html
+++ b/nodes/events-state-changed/events-state-changed.html
@@ -136,7 +136,7 @@
 
 
   <div class="form-row">
-    <label for="node-input-haltifstate"><i class="fa fa-random"></i> If State</label>
+    <label for="node-input-haltifstate"><i class="fa fa-random"></i> Halt If State</label>
     <div style="width: 70%;display: inline-block;">
       <select type="text" id="node-input-halt_if_compare" style="width: auto;">
         <option value="is">is</option>

--- a/nodes/poll-state/poll-state.html
+++ b/nodes/poll-state/poll-state.html
@@ -151,7 +151,7 @@
   </div>
 
   <div class="form-row">
-    <label for="node-input-halt_if_compare"><i class="fa fa-random"></i> If State</label>
+    <label for="node-input-halt_if_compare"><i class="fa fa-random"></i> Halt If State</label>
     <div style="width: 70%;display: inline-block;">
       <select type="text" id="node-input-halt_if_compare" style="width: auto;">
         <option value="is">is</option>


### PR DESCRIPTION
Currently, when you use a `current-state`, `events-state-changed` or `poll-state` node, you can express halt statements. However the UI labels mention **If State**, which I interpreted as _Continue If .._:

<img width="521" alt="Screenshot 2019-04-21 at 17 24 07" src="https://user-images.githubusercontent.com/2742131/56472098-b0f21480-645a-11e9-8f55-69b9e7559ca2.png">

By updating the labels to **Halt If State** this becomes less ambiguous.