### PR TITLE
Improve colors to work better in dark themes

### DIFF
--- a/lib/common/common.scss
+++ b/lib/common/common.scss
@@ -85,10 +85,15 @@ li span.property-type {
     &.tip {
         background-color: #f3f5f7;
         border-color: #42b983;
+        color: #2c3e50;
+
+        a {
+            color: #3eaf7c;
+        }
     }
 
     &.warning {
-        background-color: rgba(255, 229, 100, 0.3);
+        background-color: #fff6c6;
         border-color: #e7c000;
         color: #6b5900;
 
@@ -97,7 +102,7 @@ li span.property-type {
         }
 
         a {
-            color: #6b5900;
+            color: #2c3e50;
         }
     }
 
@@ -111,7 +116,7 @@ li span.property-type {
         }
 
         a {
-            color: #4d0000;
+            color: #2c3e50;
         }
     }
 }


### PR DESCRIPTION
The current colors for `.custom-block` don't work well in dark themes (see screenshots below). This PR tries to solve that issue.

<img width="363" alt="Screen Shot 2020-03-12 at 7 52 05 PM" src="https://user-images.githubusercontent.com/29807944/76577264-1d269e00-649b-11ea-940d-5b00a56f5235.png">

<img width="338" alt="Screen Shot 2020-03-12 at 7 52 15 PM" src="https://user-images.githubusercontent.com/29807944/76577267-1ef06180-649b-11ea-9576-ce4871c01702.png">