### PR TITLE
Fix "NaN" for events-state-changed

### DIFF
--- a/nodes/events-state-changed/events-state-changed.js
+++ b/nodes/events-state-changed/events-state-changed.js
@@ -49,7 +49,7 @@ module.exports = function (RED) {
             if (this.isEnabled === false) {
                 return;
             }
-            const { entity_id, event } = { ...evt };
+            const { entity_id, event } = JSON.parse(JSON.stringify(evt));
 
             if (!event.new_state) {
                 return null;


### PR DESCRIPTION
This is a fix for https://github.com/zachowj/node-red-contrib-home-assistant-websocket/issues/226

The root cause is the contents of `evt` changing mid-flight due to `async`/`await`. I had a 100% repro case, and I found that if I printed the contents of `event.new_state.state` just before and after `await this.getComparatorResult` the value was correct before and then `NaN` after. Here's a screenshot to demonstrate; note the highlighted debug line & code to the right:
<img width="2285" alt="Screen Shot 2020-04-02 at 4 19 28 PM" src="https://user-images.githubusercontent.com/2084821/78305309-cfcba880-74fd-11ea-9577-4971b71008e5.png">

This is because the `evt` data is only shallow-copied, so the contents of nested objects are not scoped within the execution of the function and are thus subject to mutation outside that scope.

I tried to take the lightest touch solution, i.e., deep-copy the object in a [fairly naive way](https://stackoverflow.com/questions/122102/what-is-the-most-efficient-way-to-deep-clone-an-object-in-javascript).