### PR TITLE
Make version-update link visible in dark themes

### DIFF
--- a/lib/common/common.scss
+++ b/lib/common/common.scss
@@ -9,6 +9,11 @@
     strong {
         padding-right: 5px;
     }
+
+    a,
+    a:hover {
+        color: #555;
+    }
 }
 
 #error-if-state {


### PR DESCRIPTION
Before and after.

<img width="467" alt="Screen Shot 2020-04-26 at 4 27 26 PM" src="https://user-images.githubusercontent.com/29807944/80319304-a7be2500-87dd-11ea-9108-49ea96150c7a.png">

<img width="467" alt="Screen Shot 2020-04-26 at 4 48 37 PM" src="https://user-images.githubusercontent.com/29807944/80319405-fe2b6380-87dd-11ea-847c-56dc50e5a67a.png">
