### PR TITLE
docs: change url for device-config.md

### DIFF
--- a/docs/node/entity-config.md
+++ b/docs/node/entity-config.md
@@ -13,7 +13,7 @@ The name of the entity that will show in Node-RED
 ### Device
 
 - Type: `string`
-- [device config documentation](./device-config.md)
+- [device config documentation](/node/device-config.md)
 
 A list of devices the entity can be associated with. This is used to group entities together in the UI.
 


### PR DESCRIPTION
When installing and trying to configure the `node-red-contrib-home-assistant-websocket` module I struggled with finding the linked page in the help pane in NodeRed.

Screenshot shows the link and the malformated url. The current url is `./device-config.md` and it should be `/node/device-config.md`

<img width="1741" alt="screen-2022-10-09 1100" src="https://user-images.githubusercontent.com/2266769/194779280-10d6949c-6086-48b7-98f5-7a30871d4ead.png">
