### PR TITLE
Energy dashboard in home assistant allows GJ as gas values as well

### DIFF
--- a/src/nodes/entity-config/editor/data/sensor.ts
+++ b/src/nodes/entity-config/editor/data/sensor.ts
@@ -60,7 +60,7 @@ export const sensorUnitOfMeasurement: Record<
     duration: ['d', 'h', 'min', 's'],
     energy: ['Wh', 'kWh', 'MWh', 'GJ'],
     frequency: ['Hz', 'kHz', 'MHz', 'GHz'],
-    gas: ['m³', 'ft³'],
+    gas: ['m³', 'ft³', 'GJ'],
     humidity: ['%'],
     illuminance: ['lx', 'lm'],
     moisture: ['%'],


### PR DESCRIPTION
I added it for energy ( 4e8514c ), but looking at the energy dashboard, GJ is also valid for gas, and can make sense to report it has that.