### PR TITLE
Interpret Http API params as JSON object

### DIFF
--- a/src/nodes/api/controller.js
+++ b/src/nodes/api/controller.js
@@ -109,22 +109,24 @@ class Api extends BaseNode {
         let data;
         if (parsedMessage.dataType.value === 'jsonata') {
             try {
-                data = JSON.stringify(
-                    this.evaluateJSONata(parsedMessage.data.value, { message })
-                );
+                data = this.evaluateJSONata(parsedMessage.data.value, {
+                    message,
+                });
             } catch (e) {
                 this.status.setFailed('Error');
                 done(e.message);
                 return;
             }
         } else {
-            data = renderTemplate(
-                typeof parsedMessage.data.value === 'object'
-                    ? JSON.stringify(parsedMessage.data.value)
-                    : parsedMessage.data.value,
-                message,
-                this.node.context(),
-                this.homeAssistant.getStates()
+            data = JSON.parse(
+                renderTemplate(
+                    typeof parsedMessage.data.value === 'object'
+                        ? JSON.stringify(parsedMessage.data.value)
+                        : parsedMessage.data.value,
+                    message,
+                    this.node.context(),
+                    this.homeAssistant.getStates()
+                )
             );
         }
 


### PR DESCRIPTION
When sending Params to the HTTP API through the Node Red API node, there was a consistent error "Error Message: target must be an object".

I found that the following changes avoided this error when authenticating against my Home Assistant setup and making the same API request as the current Add-on.

All tests and lint passes, Although I have not included any new tests here as I'm unsure of the procedure for testing Node Red input interpretation.