### PR TITLE
feat: add connection identifiers to device-config

### DIFF
--- a/docs/node/device-config.md
+++ b/docs/node/device-config.md
@@ -31,3 +31,27 @@ The software version of the device
 - Type: `string`
 
 The hardware version of the device
+
+### MAC Address
+
+- Type: `string`
+
+The network MAC address of the device
+
+### Bluetooth Identifier
+
+- Type: `string`
+
+The Bluetooth identifier of the device
+
+### UPnP Identifier
+
+- Type: `string`
+
+The UPnP identifier of the device
+
+### Zigbee Identifier
+
+- Type: `string`
+
+The Zigbee identifier of the device

--- a/locales/en-US/device-config.json
+++ b/locales/en-US/device-config.json
@@ -5,7 +5,11 @@
       "manufacturer": "Manufacturer",
       "model": "Model",
       "hw_version": "Hardware Version",
-      "sw_version": "Software Version"
+      "sw_version": "Software Version",
+      "macIdentifier": "MAC address",
+      "bluetoothIdentifier": "Bleutooth Identifier",
+      "upnpIdentifier": "UPnP Identifier",
+      "zigbeeIdentifier": "Zigbee Identifier"
     }
   }
 }

--- a/src/common/integration/UnidirectionalEntityIntegration.ts
+++ b/src/common/integration/UnidirectionalEntityIntegration.ts
@@ -25,6 +25,7 @@ export interface DeviceInfo {
     manufacturer?: string;
     model?: string;
     sw_version?: string;
+    connections?: Array<Array<string>>;
 }
 
 export interface DiscoveryMessage extends MessageBase {
@@ -138,6 +139,19 @@ export default class UnidirectionalIntegration extends Integration {
         }
 
         const config = this.deviceConfigNode.config;
+        const deviceConnections = [];
+        if (config.macIdentifier) {
+            deviceConnections.push(['mac', config.macIdentifier]);
+        }
+        if (config.bluetoothIdentifier) {
+            deviceConnections.push(['bluetooth', config.bluetoothIdentifier]);
+        }
+        if (config.upnpIdentifier) {
+            deviceConnections.push(['upnp', config.upnpIdentifier]);
+        }
+        if (config.zigbeeIdentiefier) {
+            deviceConnections.push(['zigbee', config.zigbeeIdentiefier]);
+        }
 
         return {
             id: config.id,
@@ -146,6 +160,7 @@ export default class UnidirectionalIntegration extends Integration {
             manufacturer: config.manufacturer,
             model: config.model,
             sw_version: config.swVersion,
+            connections: deviceConnections,
         };
     }
 

--- a/src/nodes/device-config/editor.html
+++ b/src/nodes/device-config/editor.html
@@ -39,3 +39,35 @@
     ></label>
     <input type="text" id="node-config-input-hwVersion" />
 </div>
+
+<div class="form-row">
+    <label
+        for="node-config-input-macIdentifier"
+        data-i18n="ha-device-config.label.macIdentifier"
+    ></label>
+    <input type="text" id="node-config-input-macIdentifier" />
+</div>
+
+<div class="form-row">
+    <label
+        for="node-config-input-bluetoothIdentifier"
+        data-i18n="ha-device-config.label.bluetoothIdentifier"
+    ></label>
+    <input type="text" id="node-config-input-bluetoothIdentifier" />
+</div>
+
+<div class="form-row">
+    <label
+        for="node-config-input-upnpIdentifier"
+        data-i18n="ha-device-config.label.upnpIdentifier"
+    ></label>
+    <input type="text" id="node-config-input-upnpIdentifier" />
+</div>
+
+<div class="form-row">
+    <label
+        for="node-config-input-zigbeeIdentifier"
+        data-i18n="ha-device-config.label.zigbeeIdentifier"
+    ></label>
+    <input type="text" id="node-config-input-zigbeeIdentifier" />
+</div>

--- a/src/nodes/device-config/editor.ts
+++ b/src/nodes/device-config/editor.ts
@@ -10,6 +10,10 @@ export interface DeviceConfigEditorNodeProperties extends EditorNodeProperties {
     manufacturer: string;
     model: string;
     swVersion: string;
+    macIdentifier: string;
+    bluetoothIdentifier: string;
+    upnpIdentifier: string;
+    zigbeeIdentiefier: string;
 }
 
 const DeviceConfigEditor: EditorNodeDef<DeviceConfigEditorNodeProperties> = {
@@ -21,6 +25,10 @@ const DeviceConfigEditor: EditorNodeDef<DeviceConfigEditorNodeProperties> = {
         manufacturer: { value: 'Node-RED', required: false },
         model: { value: '', required: false },
         swVersion: { value: '', required: false },
+        macIdentifier: { value: '', required: false },
+        bluetoothIdentifier: { value: '', required: false },
+        upnpIdentifier: { value: '', required: false },
+        zigbeeIdentiefier: { value: '', required: false },
     },
     icon: 'font-awesome/fa-device',
     label: function (): string {

--- a/src/nodes/device-config/index.ts
+++ b/src/nodes/device-config/index.ts
@@ -7,6 +7,10 @@ export interface DeviceConfigNodeProperties extends BaseNodeProperties {
     manufacturer?: string;
     model?: string;
     swVersion?: string;
+    macIdentifier?: string;
+    bluetoothIdentifier?: string;
+    upnpIdentifier?: string;
+    zigbeeIdentiefier?: string;
 }
 
 export interface DeviceConfigNode extends BaseNode {


### PR DESCRIPTION
## Description
Changes to the `device-config`-node and related files to make it possible to share device identifiers with Home Assistant.

## Motivation and Context
As the IOT space keeps growing having the possibility to combine Node-Red entities with existing devices in Home Assistant is a needed option.

## How Has This Been Tested?
- Used the supplied dev-container for development and testing.
- Ran `npm run lint` with no errors.
- Ran `npm run test` with no errors.
- Ran `npm run dev` with no errors.
- Connected Node-Red to Home Assistant and got a working Entity with Device matched to already existing Device with the MAC address as the identifier
- Connected Node-Red to Home Assistant and got a working Entity with Device with all new fields left empty.

## Not Tested / Possibly missing
- No tests done for the Bluetooth Identifier
- No tests done for the UPnP Identifier
- No tests done for the Zigbee Identifier
- Did not check cookbook for needed updates
- As I have no experience with the `migrations.ts` file(s) no work has been done on this part, don't know if this is needed.
- Did not do any work with/on the `device`-node