### PR TITLE
Let themes define select2 dropdown background color

### DIFF
--- a/src/editor/css/select2/layout.scss
+++ b/src/editor/css/select2/layout.scss
@@ -127,6 +127,7 @@
     }
 
     .select2-dropdown {
+        background-color: $secondary-background;
         border-color: $form-input-border-color;
     }
 }


### PR DESCRIPTION
If a theme has border colors with an alpha value, the default white background color of the select2 dropdown causes the issue shown in the screenshot below.

<img width="350" alt="SCR-20240121-gqle" src="https://github.com/zachowj/node-red-contrib-home-assistant-websocket/assets/29807944/c0537a4e-d744-40bb-9872-acd186937ee9">

This PR fixes the issue by letting themes define that background color.

Screenshot with the fix:

<img width="350" alt="SCR-20240121-gqqe" src="https://github.com/zachowj/node-red-contrib-home-assistant-websocket/assets/29807944/c7ffe88c-1056-4517-98c3-8843e0fb4c4c">
