### PR TITLE
Clarify docs for "curent state" node

### DIFF
--- a/docs/node/current-state.md
+++ b/docs/node/current-state.md
@@ -27,7 +27,7 @@ output.
 
 - Type: `number`
 
-The amount of time the entity state needs to constant for the "If state" to be `true`
+The amount of time the entity state needs to have been constant for the "If state" to be `true`
 
 ### State Type
 


### PR DESCRIPTION
I think that the documentation of the "for" option in the "current state" node could be improved with just a small change.

When I first used this node I thought it would check for the given amount of time _starting_ when the node ist triggered. But actually when the node is triggered, it _looks back_ in time to see for how long the state has been constant.

The proposed change in wording better reflects this in my opinion.