### PR TITLE
fixing reconnect handling

### DIFF
--- a/src/homeAssistant/Websocket.ts
+++ b/src/homeAssistant/Websocket.ts
@@ -555,6 +555,7 @@ export default class Websocket {
         this.isHomeAssistantRunning = false;
         this.connectionState = ClientState.Connected;
         if (this.#config.heartbeatInterval) {
+            this.#stopAssignedHeartbeat();
             this.#stopHeartbeat = startHeartbeat(
                 this.client,
                 this.#config.heartbeatInterval,
@@ -581,11 +582,20 @@ export default class Websocket {
     }
 
     close(): void {
-        if (typeof this.#stopHeartbeat === 'function') this.#stopHeartbeat();
+        this.#stopAssignedHeartbeat();
         this?.client?.close();
     }
 
+    #stopAssignedHeartbeat(): void {
+        if (typeof this.#stopHeartbeat === 'function') {
+            const stopHeartbeat = this.#stopHeartbeat;
+            this.#stopHeartbeat = undefined;
+            stopHeartbeat();
+        }
+    }
+
     resetClient(): void {
+        this.#stopAssignedHeartbeat();
         this.integrationVersion = NO_VERSION;
         this.isHomeAssistantRunning = false;
         this.#servicesLoaded = false;


### PR DESCRIPTION
After a reconnect the old heartbeat checker was not finished, but a new heartbeat checker was created. After many reconnects, the checkers stopped working because some checker always recognized a timeout and caused a new reconnect.

The fix ensures that before creating a new heartbeat checker, the old one is stopped. Also on reset a connection, the old one is stopped.

This solves the reconnect problem for me:

```text
nodered-1  | 5 Oct 16:55:46 - [info] [server:Home Assistant] Connection closed to http://localhost
nodered-1  | 5 Oct 16:55:46 - [info] [server:Home Assistant] Connecting to http://localhost
nodered-1  | 5 Oct 16:55:46 - [info] [server:Home Assistant] Connected to http://localhost
nodered-1  | 5 Oct 16:55:46 - [info] [server:Home Assistant] Connection closed to http://localhost
nodered-1  | 5 Oct 16:55:46 - [info] [server:Home Assistant] Connecting to http://localhost
nodered-1  | 5 Oct 16:55:46 - [info] [server:Home Assistant] Connected to http://localhost
nodered-1  | 5 Oct 16:55:51 - [info] [server:Home Assistant] Connection closed to http://localhost
nodered-1  | 5 Oct 16:55:51 - [info] [server:Home Assistant] Connecting to http://localhost
nodered-1  | 5 Oct 16:55:51 - [info] [server:Home Assistant] Connected to http://localhost
nodered-1  | 5 Oct 16:55:56 - [info] [server:Home Assistant] Connection closed to http://localhost
```

Similar issue: [#1425](https://github.com/zachowj/node-red-contrib-home-assistant-websocket/issues/1425)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved management of the heartbeat mechanism to prevent multiple active heartbeats.
- **Refactor**
	- Centralized heartbeat stopping logic for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->