### PR TITLE
feat: Set `timeout` flag when `wait-until` timeouted

### DIFF
--- a/src/nodes/wait-until/WaitUntilController.ts
+++ b/src/nodes/wait-until/WaitUntilController.ts
@@ -267,6 +267,7 @@ export default class WaitUntil extends InputOutputController<
                         {
                             entity: state,
                             config: this.node.config,
+                            timeout: true,
                         },
                     );
 


### PR DESCRIPTION
Very simple, yet helpful addition to `wait-until` node's timeout output.

Sometimes this node is a beginning to a big flow that may run some portion if state timeout'd. Both outputs may connect to the same next node, but it may be a `switch` that performs slightly different actions on state reached or timeout.

I'm not sure if I made the addition in a correct place and, true – I haven't tested this locally – but that effort would be much bigger than just creating this PR. Therefore I ask for your understanding. :)