### PR TITLE
Add support for m/min unit of measurement for speed

### DIFF
--- a/src/nodes/entity-config/editor/data/sensor.ts
+++ b/src/nodes/entity-config/editor/data/sensor.ts
@@ -153,6 +153,7 @@ export const sensorUnitOfMeasurement: Record<
         'in/h',
         'km/h',
         'kn',
+        'm/min',
         'm/s',
         'mm/s',
         'mm/h',


### PR DESCRIPTION
This PR adds support for the m/min (meters per minute) unit of measurement for speed.
It follows up on the recently merged [home-assistant/core#146441](https://github.com/home-assistant/core/pull/146441) which introduced `m/min` as a valid speed unit in the Home Assistant core.

With this change, integrations and custom components that report speed in meters per minute can now use the standardized unit, ensuring consistency across the Home Assistant ecosystem.

**Changes included:**

Added m/min to the list of supported speed units.


**Why:**
Some devices and industrial systems report speed in meters per minute. By supporting this unit natively, we improve compatibility and prevent the need for custom conversions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now choose meters per minute (m/min) as a speed unit when configuring sensors in the entity configuration editor, alongside existing options like m/s, km/h, mph, and knots. This expands compatibility with devices reporting speed in m/min and ensures values display using your preferred unit throughout the UI and automations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->