### PR TITLE
Fix documentation: invalid example input for action node

### DIFF
--- a/docs/node/action.md
+++ b/docs/node/action.md
@@ -94,7 +94,7 @@ Sample input
 
 ```JSON
 {
-    "action": "homeassistant.turn_on",
+    "action": "light.turn_on",
     "target": {
         "floor_id": ["first_floor"],
         "area_id": ["kitchen"],


### PR DESCRIPTION
The provided input is not valid and is misleading, as the action needs to be named as in a normal home assistant action, 

not "'homeassistant.turn" 

but 'light.turn_on'

as in the example is manipulated a light entity