### PR TITLE
chore: align existing source with current prettier

### DIFF
--- a/src/common/integration/BidirectionalEntityIntegration.ts
+++ b/src/common/integration/BidirectionalEntityIntegration.ts
@@ -30,8 +30,7 @@ export interface ValueChangedEvent {
 }
 
 export type HaEventMessage =
-    | StateChangeEvent
-    | TriggerEvent
+    StateChangeEvent | TriggerEvent
     | ValueChangedEvent;
 
 export interface StateChangePayload {

--- a/src/common/integration/UnidirectionalEntityIntegration.ts
+++ b/src/common/integration/UnidirectionalEntityIntegration.ts
@@ -339,7 +339,6 @@ export default class UnidirectionalIntegration extends Integration {
      */
     public getHaConfigFromContext(): Record<string, any> | undefined {
         return this.entityConfigNode.context().get('haConfig') as
-            | Record<string, any>
-            | undefined;
+            Record<string, any> | undefined;
     }
 }

--- a/src/editor/data.ts
+++ b/src/editor/data.ts
@@ -89,10 +89,7 @@ export function getAutocomplete(serverId: string, type: any) {
 }
 
 export type AutocompleteType =
-    | 'entities'
-    | 'properties'
-    | 'trackers'
-    | 'zones'
+    'entities' | 'properties' | 'trackers' | 'zones'
     | 'calendars';
 export function getAutocompleteData(serverId: string, type: AutocompleteType) {
     let list: { value: any; label: any }[] = [];

--- a/src/nodes/config-server/EditorContext.ts
+++ b/src/nodes/config-server/EditorContext.ts
@@ -37,8 +37,7 @@ export default class EditorContext {
         this.#node = node;
 
         const globalContext = this.#node.context().global.get(NAMESPACE) as
-            | HomeAssistantGlobalContext
-            | undefined;
+            HomeAssistantGlobalContext | undefined;
 
         if (!globalContext?.[this.#serverName]) {
             if (!globalContext) {

--- a/src/nodes/get-history/const.ts
+++ b/src/nodes/get-history/const.ts
@@ -1,9 +1,9 @@
 export enum OutputType {
-    'Array' = 'array',
-    'Split' = 'split',
+    Array = 'array',
+    Split = 'split',
 }
 
 export enum EntityFilterType {
-    'Equals' = 'equals',
-    'Regex' = 'regex',
+    Equals = 'equals',
+    Regex = 'regex',
 }

--- a/src/nodes/number/NumberController.ts
+++ b/src/nodes/number/NumberController.ts
@@ -29,8 +29,7 @@ export default class NumberController extends InputOutputController<
 
     async #onInputModeGet({ done, message, send }: InputProperties) {
         const value = this.#entityConfigNode?.state?.getLastPayload()?.state as
-            | string
-            | undefined;
+            string | undefined;
 
         this.status.setSuccess(value);
         await this.setCustomOutputs(

--- a/src/nodes/select/SelectController.ts
+++ b/src/nodes/select/SelectController.ts
@@ -29,8 +29,7 @@ export default class SelectController extends InputOutputController<
 
     async #onInputModeGet({ done, message, send }: InputProperties) {
         const value = this.#entityConfigNode?.state?.getLastPayload()?.state as
-            | string
-            | undefined;
+            string | undefined;
 
         this.status.setSuccess(value);
         await this.setCustomOutputs(

--- a/src/nodes/text/TextController.ts
+++ b/src/nodes/text/TextController.ts
@@ -29,8 +29,7 @@ export default class TextController extends InputOutputController<
 
     async #onInputModeGet({ done, message, send }: InputProperties) {
         const value = this.#entityConfigNode?.state?.getLastPayload()?.state as
-            | string
-            | undefined;
+            string | undefined;
 
         this.status.setSuccess(value);
         await this.setCustomOutputs(


### PR DESCRIPTION
## Summary

This is a formatting-only maintenance PR. It applies the current Prettier output to the eight source files reported by the CI lint job for [PR #2025](https://github.com/zachowj/node-red-contrib-home-assistant-websocket/pull/2025).

It is intentionally separate from the CPU optimisation. No runtime behaviour, tests, dependencies, or Node-RED integration logic are changed.

## Why this is separate

PR #2025 is a focused performance change, but its CI cannot reach the test stage because the repository-wide lint job reports these existing formatting errors. Merging this small prerequisite PR would clear that baseline lint failure and allow #2025 to be reviewed and tested normally.

The formatting changes are limited to the files reported by CI:

- `src/common/integration/BidirectionalEntityIntegration.ts`
- `src/common/integration/UnidirectionalEntityIntegration.ts`
- `src/editor/data.ts`
- `src/nodes/config-server/EditorContext.ts`
- `src/nodes/get-history/const.ts`
- `src/nodes/number/NumberController.ts`
- `src/nodes/select/SelectController.ts`
- `src/nodes/text/TextController.ts`

## Validation

```sh
pnpm run lint
pnpm test
```

The purpose of this PR is to clear the lint gate so the full test matrix for #2025 can run.
