### PR TITLE
fix(socket): time out a stalled connect/auth handshake so retry can fire

### DIFF
--- a/src/homeAssistant/createSocket.ts
+++ b/src/homeAssistant/createSocket.ts
@@ -13,6 +13,17 @@ import { ClientEvent } from './Websocket';
 
 const debug = Debug('home-assistant:socket');
 
+// Time budgets for the connect/auth handshake. A half-open connection -- the
+// server completes the TCP handshake but never finishes the WebSocket upgrade
+// (no 101 response), or upgrades but never sends auth_ok (e.g. a Home Assistant
+// wedged in uninterruptible I/O wait) -- otherwise fires no open/message/close/
+// error event, so the connect promise never settles and no retry ever runs. The
+// node then sits at 'connecting' indefinitely. These timeouts force a teardown
+// so the existing close/error retry path below fires as it does for every other
+// connection failure.
+const HANDSHAKE_TIMEOUT = 15000; // WS HTTP-upgrade (101) must complete within this
+const AUTH_TIMEOUT = 45000; // auth_ok must arrive within this after a connect attempt starts
+
 interface HaWebSocket extends WebSocket {
     haVersion: string;
 }
@@ -49,11 +60,32 @@ export default function createSocket({
         eventBus.emit(ClientEvent.Connecting);
 
         const socket = new WebSocket(url, {
+            handshakeTimeout: HANDSHAKE_TIMEOUT,
             rejectUnauthorized: rejectUnauthorizedCerts,
         }) as HaWebSocket;
 
         // If invalid auth, we will not try to reconnect.
         let invalidAuth = false;
+
+        // If auth_ok has not arrived in time, tear the socket down. terminate()
+        // (not close()) guarantees a prompt 'close' even on a wedged, half-open
+        // socket whose peer will never complete a closing handshake.
+        let authTimeout: ReturnType<typeof setTimeout> | undefined = setTimeout(
+            () => {
+                debug(
+                    '[Auth Phase] auth handshake timed out after %dms, terminating',
+                    AUTH_TIMEOUT,
+                );
+                socket.terminate();
+            },
+            AUTH_TIMEOUT,
+        );
+        const clearAuthTimeout = () => {
+            if (authTimeout) {
+                clearTimeout(authTimeout);
+                authTimeout = undefined;
+            }
+        };
 
         const onOpen = async () => {
             try {
@@ -78,6 +110,7 @@ export default function createSocket({
                     break;
 
                 case MSG_TYPE_AUTH_OK:
+                    clearAuthTimeout();
                     socket.off('open', onOpen);
                     socket.off('message', onMessage);
                     socket.off('close', onClose);
@@ -104,6 +137,7 @@ export default function createSocket({
         };
 
         const onClose = () => {
+            clearAuthTimeout();
             // If we are in error handler make sure close handler doesn't also fire.
             socket.off('close', onClose);
             if (invalidAuth) {


### PR DESCRIPTION

## Summary

Adds two timeouts to the connect/auth handshake in `createSocket.ts` so a half-open
connection can no longer wedge the client at `connecting` forever.

Fixes #2027.

## The bug

`connect()` only ever settles the connection promise or schedules a retry from the socket's
`open` / `message` / `close` / `error` events. If the server accepts the TCP connection but
never completes the application-layer handshake — it never returns the WebSocket `101`
upgrade, or upgrades but never sends `auth_ok` — **none of those events fire**. The promise
returned to `createConnection()` never settles, and the `onClose` retry (`setTimeout(… , 5000)`)
is never scheduled. The node stays at `connecting` indefinitely (21 hours, in the report)
until Node-RED is restarted.

This happens in the real world when the HA host's kernel is alive (answers ARP, completes TCP
handshakes) but the HA process is blocked — e.g. storage stall / uninterruptible I/O wait.
Every other failure mode (RST, ICMP unreachable, blackholed packets) recovers, because each
produces a `close`/`error`. Heartbeat doesn't help — it only runs after the connection is
established, which never happens here.

## The fix

- **`handshakeTimeout` on the `ws` socket** — `ws` emits `error` if the opening HTTP
  handshake (the `101` upgrade) doesn't complete in time. Covers the never-upgrades case
  (the deterministic bare-TCP-listener repro).
- **An overall auth deadline** — a `setTimeout` armed when the connect attempt starts that
  calls `socket.terminate()` if `auth_ok` hasn't arrived. Covers the case where the upgrade
  completes but auth never does. `terminate()` (not `close()`) is used deliberately: it
  forces a prompt `close` even on a wedged socket whose peer will never complete a closing
  handshake.

Both simply route into the **existing** `onClose` retry path — no new retry logic. The timer
is cleared on `auth_ok` and on `close` to avoid leaks or terminating a subsequent socket.

Defaults: `HANDSHAKE_TIMEOUT = 15000`, `AUTH_TIMEOUT = 45000` (named constants at the top of
the file). Generous relative to a healthy handshake; happy to adjust or make configurable.

## Testing

Against the bare-TCP-listener repro from the issue:

| | connect attempts observed | outcome |
|---|---|---|
| before | 1, then silence forever | hangs, never retries |
| after | recurring, every ~20s (15s handshake + 5s retry) | recovers; connects as soon as a real HA answers |

Note the retry cadence against a *silent* server is ~20s rather than the ~5s seen for an
actively-refused connection, because the dead handshake now takes 15s to detect before the
existing 5s retry delay. Healthy connections are unaffected — the timers are cleared on
`auth_ok`.

## Notes

- No behavior change for any connection that already fires `open`/`close`/`error`.
- No public API change; constants can be promoted to config later if desired.
