### PR TITLE
ci: fix format-docs checkout for fork pull requests

### DIFF
--- a/.github/workflows/format-docs.yml
+++ b/.github/workflows/format-docs.yml
@@ -13,15 +13,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
-          # This is important to fetch the changes to the previous commit
+          # Fork PRs: head_ref only exists on the head repo, not upstream origin
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prettify code
+      - name: Prettify and commit (same-repo PR)
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: creyD/prettier_action@v4.5
         with:
-          # This part is also where you can pass other options, for example:
           prettier_options: --write docs/**/*.md
           only_changed: True
           same_commit: True
+
+      - name: Check docs formatting (fork PR)
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        uses: creyD/prettier_action@v4.5
+        with:
+          # GITHUB_TOKEN cannot push to a fork; check only
+          prettier_options: --check docs/**/*.md
+          only_changed: True


### PR DESCRIPTION
## Summary
- Check out the PR **head repository** and branch so `format-docs` works for fork PRs (previously used `ref: github.head_ref` against upstream `origin`, which does not have the fork branch).
- Keep automatic prettier write + `same_commit` only for **in-repo** PRs.
- Fork PRs run prettier `--check` only: upstream `GITHUB_TOKEN` cannot push formatting commits back to a fork.

## Why
Any fork PR that touched `docs/**` failed CI at checkout with “branch could not be found”, before prettier ran. That blocked contributors even when docs were fine.

## Behaviour change
**Automatic docs cleanup (write + commit back to the PR branch) is now only done for same-repository PRs.** Fork PRs are validated with `--check` and must already be formatted.

## Test plan
- [ ] In-repo PR touching `docs/**`: workflow checks out, formats if needed, commits back as before
- [ ] Fork PR touching `docs/**`: workflow checks out the fork branch successfully; `--check` passes or fails on real formatting issues (no checkout error)


Made with [Cursor](https://cursor.com)