### PR TITLE
Keep HA websocket open until entity unregister finishes

### DIFF
--- a/src/common/integration/BidirectionalEntityIntegration.ts
+++ b/src/common/integration/BidirectionalEntityIntegration.ts
@@ -76,7 +76,7 @@ export default class BidirectionalIntegration extends UnidirectionalEntityIntegr
             status?.setSuccess('home-assistant.status.registered'),
         );
 
-        this.registered = true;
+        this.markRegistered();
     }
 
     protected async unregister() {

--- a/src/common/integration/UnidirectionalEntityIntegration.ts
+++ b/src/common/integration/UnidirectionalEntityIntegration.ts
@@ -48,6 +48,7 @@ export interface UnidirectionalIntegrationConstructor extends IntegrationConstru
 export default class UnidirectionalIntegration extends Integration {
     protected readonly deviceConfigNode?: DeviceConfigNode;
     protected readonly entityConfigNode: EntityConfigNode;
+    #entityRefHeld = false;
 
     constructor(props: UnidirectionalIntegrationConstructor) {
         super(props);
@@ -67,13 +68,33 @@ export default class UnidirectionalIntegration extends Integration {
         super.init();
     }
 
+    protected markRegistered(): void {
+        this.registered = true;
+        if (!this.#entityRefHeld) {
+            this.homeAssistant.acquireEntityRef();
+            this.#entityRefHeld = true;
+        }
+    }
+
+    protected releaseEntityRef(): void {
+        if (!this.#entityRefHeld) {
+            return;
+        }
+        this.homeAssistant.releaseEntityRef();
+        this.#entityRefHeld = false;
+    }
+
     protected async onEntityConfigNodeClose(removed: boolean, done: NodeDone) {
-        if (this.registered && this.isIntegrationLoaded && removed) {
-            try {
+        try {
+            if (this.registered && this.isIntegrationLoaded && removed) {
                 await this.unregister();
-            } catch (err) {
-                done(err as Error);
             }
+        } catch (err) {
+            done(err as Error);
+            return;
+        } finally {
+            this.releaseEntityRef();
+            this.registered = false;
         }
         done();
     }
@@ -202,7 +223,7 @@ export default class UnidirectionalIntegration extends Integration {
             status?.setSuccess('home-assistant.status.registered'),
         );
 
-        this.registered = true;
+        this.markRegistered();
     }
 
     public setStatus(status: Status) {

--- a/src/homeAssistant/HomeAssistant.ts
+++ b/src/homeAssistant/HomeAssistant.ts
@@ -31,6 +31,8 @@ const httpMethods: string[] = [
     'renderTemplate',
 ];
 
+const DEFAULT_CLOSE_DRAIN_TIMEOUT_MS = 2000;
+
 export default class HomeAssistant {
     // TODO: this can be made private after typescript conversion
     public eventsList: { [nodeId: string]: string } = {};
@@ -38,6 +40,15 @@ export default class HomeAssistant {
     eventBus: EventEmitter;
     http: httpAPI;
     websocket: websocketAPI;
+
+    /**
+     * Registered entity integrations that may still need the websocket
+     * during Node-RED close (e.g. to send remove: true). Server close waits
+     * until this hits zero so unregister is not racing client.close().
+     */
+    #entityRefs = 0;
+    #refsIdle = Promise.resolve();
+    #resolveRefsIdle: (() => void) | null = null;
 
     constructor({
         websocketAPI,
@@ -55,6 +66,31 @@ export default class HomeAssistant {
 
         this.exposeMethods(this.websocket, websocketMethods);
         this.exposeMethods(this.http, httpMethods);
+    }
+
+    acquireEntityRef(): void {
+        this.#entityRefs += 1;
+        if (this.#entityRefs === 1) {
+            this.#refsIdle = new Promise((resolve) => {
+                this.#resolveRefsIdle = resolve;
+            });
+        }
+    }
+
+    releaseEntityRef(): void {
+        if (this.#entityRefs <= 0) {
+            return;
+        }
+        this.#entityRefs -= 1;
+        if (this.#entityRefs === 0) {
+            this.#resolveRefsIdle?.();
+            this.#resolveRefsIdle = null;
+            this.#refsIdle = Promise.resolve();
+        }
+    }
+
+    get entityRefCount(): number {
+        return this.#entityRefs;
     }
 
     get isConnected(): boolean {
@@ -108,8 +144,25 @@ export default class HomeAssistant {
         return this.websocket.subscribeEvents(this.eventsList);
     }
 
-    close(): void {
-        this?.websocket?.close();
+    async close({ timeoutMs }: { timeoutMs?: number } = {}): Promise<void> {
+        const drainMs = timeoutMs ?? DEFAULT_CLOSE_DRAIN_TIMEOUT_MS;
+        if (this.#entityRefs > 0) {
+            debug(
+                `Waiting for ${this.#entityRefs} entity ref(s) before closing websocket`,
+            );
+            await Promise.race([
+                this.#refsIdle,
+                new Promise<void>((resolve) => {
+                    setTimeout(resolve, drainMs);
+                }),
+            ]);
+            if (this.#entityRefs > 0) {
+                debug(
+                    `Timed out waiting for entity refs (${this.#entityRefs} remaining); closing websocket anyway`,
+                );
+            }
+        }
+        this.websocket?.close();
     }
 
     addListener(

--- a/src/homeAssistant/index.ts
+++ b/src/homeAssistant/index.ts
@@ -192,10 +192,10 @@ export function getHomeAssistant(
     );
 }
 
-export function closeHomeAssistant(nodeId: string): void {
+export async function closeHomeAssistant(nodeId: string): Promise<void> {
     const homeAssistant = homeAssistantConnections.get(nodeId);
     if (homeAssistant) {
-        homeAssistant.close();
+        await homeAssistant.close();
         homeAssistantConnections.delete(nodeId);
     }
 }

--- a/src/nodes/config-server/index.ts
+++ b/src/nodes/config-server/index.ts
@@ -23,9 +23,14 @@ export default function configServerNode(
     createHomeAssistantClient(this);
 
     this.on(NodeEvent.Close, (_removed: boolean, done: NodeDone) => {
-        closeHomeAssistant(this.id);
-        // @ts-expect-error - set context second argument is optional
-        this.context().global.set('homeassistant');
-        done();
+        closeHomeAssistant(this.id)
+            .catch((err: Error) => {
+                this.error(err);
+            })
+            .finally(() => {
+                // @ts-expect-error - set context second argument is optional
+                this.context().global.set('homeassistant');
+                done();
+            });
     });
 }

--- a/test/unit/homeAssistant/HomeAssistant.test.ts
+++ b/test/unit/homeAssistant/HomeAssistant.test.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mock, MockProxy } from 'vitest-mock-extended';
+
+import HomeAssistant from '../../../src/homeAssistant/HomeAssistant';
+import HttpAPI from '../../../src/homeAssistant/Http';
+import WebsocketAPI from '../../../src/homeAssistant/Websocket';
+
+describe('HomeAssistant entity refs', function () {
+    let homeAssistant: HomeAssistant;
+    let websocket: MockProxy<WebsocketAPI>;
+
+    beforeEach(function () {
+        websocket = mock<WebsocketAPI>();
+        homeAssistant = new HomeAssistant({
+            websocketAPI: websocket,
+            httpAPI: mock<HttpAPI>(),
+            eventBus: new EventEmitter(),
+        });
+    });
+
+    afterEach(function () {
+        vi.useRealTimers();
+    });
+
+    it('acquire and release track the ref count', function () {
+        expect(homeAssistant.entityRefCount).toBe(0);
+
+        homeAssistant.acquireEntityRef();
+        homeAssistant.acquireEntityRef();
+        expect(homeAssistant.entityRefCount).toBe(2);
+
+        homeAssistant.releaseEntityRef();
+        expect(homeAssistant.entityRefCount).toBe(1);
+
+        homeAssistant.releaseEntityRef();
+        expect(homeAssistant.entityRefCount).toBe(0);
+    });
+
+    it('release below zero is a no-op', function () {
+        homeAssistant.releaseEntityRef();
+        expect(homeAssistant.entityRefCount).toBe(0);
+    });
+
+    it('close with no refs closes the websocket immediately', async function () {
+        await homeAssistant.close();
+        expect(websocket.close).toHaveBeenCalledOnce();
+    });
+
+    it('close waits until entity refs are released', async function () {
+        homeAssistant.acquireEntityRef();
+
+        let closed = false;
+        const closing = homeAssistant.close({ timeoutMs: 5_000 }).then(() => {
+            closed = true;
+        });
+
+        await Promise.resolve();
+        expect(closed).toBe(false);
+        expect(websocket.close).not.toHaveBeenCalled();
+
+        homeAssistant.releaseEntityRef();
+        await closing;
+
+        expect(closed).toBe(true);
+        expect(websocket.close).toHaveBeenCalledOnce();
+    });
+
+    it('close times out and closes with refs still held', async function () {
+        vi.useFakeTimers();
+        homeAssistant.acquireEntityRef();
+
+        const closing = homeAssistant.close({ timeoutMs: 100 });
+        await vi.advanceTimersByTimeAsync(100);
+        await closing;
+
+        expect(homeAssistant.entityRefCount).toBe(1);
+        expect(websocket.close).toHaveBeenCalledOnce();
+    });
+});


### PR DESCRIPTION
## Summary
- Refcount registered entity integrations on the shared Home Assistant client.
- Server config `close` waits until the count hits zero (with timeout) before `client.close()`.
- Entity-config close releases its ref in `finally` after awaiting `remove: true` when deleted.

## Why
On full deploy, Node-RED stops global config nodes in the same wave and does not wait for async close handlers. The server config was closing the websocket while entity-config was still awaiting unregister (`ERR_CONNECTION_LOST` / error code 3), so Home Assistant never received `remove: true`.

## Notes
- Companion registry cleanup: https://github.com/zachowj/hass-node-red/pull/402
- Replaces #2030 / #2031 — **feature + unit tests only** (no drive-by prettier).
- **CI:** `pnpm lint` will fail on this branch until [#2033](https://github.com/zachowj/node-red-contrib-home-assistant-websocket/pull/2033) lands and this PR is rebased onto it. That failure is pre-existing prettier drift on `main`, not this change — once rebased, CI should pass for this PR’s content.

## Test plan
- [x] Unit tests for acquire/release/`close` wait/timeout (`HomeAssistant.test.ts`)
- [x] Full test suite green
- [x] Smoke: NR full deploy create → delete entity; HA logs `Removing` even while server closes in the same deploy
- [x] Inverse: contrib fix + companion main → remove arrives, entity remains (companion gap)