### PR TITLE
feat(ha): announce package version on nodered/version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - name: pnpm install
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Install exact version of node-red
         run: pnpm add -D node-red@${{ matrix.node-red-version }}
       - name: pnpm lint
@@ -84,7 +84,7 @@ jobs:
         with:
           cache: pnpm
       - name: pnpm install
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Pack
         run: pnpm pack
       - name: Upload Release Asset

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm docs:build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/format-docs.yml
+++ b/.github/workflows/format-docs.yml
@@ -23,6 +23,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: creyD/prettier_action@v4.5
         with:
+          prettier_version: 3.9.6
           prettier_options: --write docs/**/*.md
           only_changed: True
           same_commit: True
@@ -32,5 +33,6 @@ jobs:
         uses: creyD/prettier_action@v4.5
         with:
           # GITHUB_TOKEN cannot push to a fork; check only
+          prettier_version: 3.9.6
           prettier_options: --check docs/**/*.md
           only_changed: True

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,6 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies and build 🔧
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Publish package on NPM
         run: pnpm publish

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "node-red": "^4.1.3",
     "node-red-node-test-helper": "^0.3.6",
     "postcss": "^8.5.6",
-    "prettier": "^3.8.1",
+    "prettier": "^3.9.6",
     "sass": "^1.97.3",
     "typescript": "^5.9.3",
     "vitest": "^4.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,7 +176,7 @@ importers:
         version: 16.6.2(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: ^5.5.5
-        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.8.1)
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       eslint-plugin-promise:
         specifier: ^6.6.0
         version: 6.6.0(eslint@8.57.1)
@@ -229,8 +229,8 @@ importers:
         specifier: ^8.5.6
         version: 8.5.6
       prettier:
-        specifier: ^3.8.1
-        version: 3.8.1
+        specifier: ^3.9.6
+        version: 3.9.6
       sass:
         specifier: ^1.97.3
         version: 1.97.3
@@ -4084,8 +4084,8 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6486,18 +6486,6 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/helper@2.0.0-rc.122(typescript@5.9.3)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@22.19.7)(sass@1.97.3)(terser@5.26.0)(typescript@5.9.3)(yaml@2.8.1))(typescript@5.9.3)(vue@3.5.27(typescript@5.9.3)))':
-    dependencies:
-      '@vue/shared': 3.5.27
-      '@vueuse/core': 14.2.0(vue@3.5.27(typescript@5.9.3))
-      cheerio: 1.2.0
-      fflate: 0.8.2
-      gray-matter: 4.0.3
-      vue: 3.5.27(typescript@5.9.3)
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@22.19.7)(sass@1.97.3)(terser@5.26.0)(typescript@5.9.3)(yaml@2.8.1))(typescript@5.9.3)(vue@3.5.27(typescript@5.9.3))
-    transitivePeerDependencies:
-      - typescript
-
   '@vuepress/highlighter-helper@2.0.0-rc.118(@vueuse/core@14.1.0(vue@3.5.27(typescript@5.9.3)))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@22.19.7)(sass@1.97.3)(terser@5.26.0)(typescript@5.9.3)(yaml@2.8.1))(typescript@5.9.3)(vue@3.5.27(typescript@5.9.3)))':
     dependencies:
       vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@22.19.7)(sass@1.97.3)(terser@5.26.0)(typescript@5.9.3)(yaml@2.8.1))(typescript@5.9.3)(vue@3.5.27(typescript@5.9.3))
@@ -7904,10 +7892,10 @@ snapshots:
       resolve: 1.22.10
       semver: 7.7.2
 
-  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.8.1):
+  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6):
     dependencies:
       eslint: 8.57.1
-      prettier: 3.8.1
+      prettier: 3.9.6
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
@@ -9557,7 +9545,7 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier@3.8.1: {}
+  prettier@3.9.6: {}
 
   prismjs@1.30.0: {}
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -7,6 +7,8 @@ export const INTEGRATION_LOADED = 'loaded';
 export const INTEGRATION_NOT_LOADED = 'notloaded';
 export const INTEGRATION_UNLOADED = 'unloaded';
 export const NO_VERSION = '0.0.0';
+/** Companion version that accepts optional contrib_version on nodered/version */
+export const COMPANION_MIN_VERSION_CONTRIB_HANDSHAKE = '4.2.4';
 export const STATE_CONNECTING = 0;
 export const STATE_CONNECTED = 1;
 export const STATE_DISCONNECTED = 2;

--- a/src/homeAssistant/Websocket.ts
+++ b/src/homeAssistant/Websocket.ts
@@ -1,3 +1,4 @@
+import { compareVersions } from 'compare-versions';
 import Debug from 'debug';
 import { EventEmitter } from 'events';
 import {
@@ -25,6 +26,7 @@ import {
 import { cloneDeep } from 'lodash';
 
 import {
+    COMPANION_MIN_VERSION_CONTRIB_HANDSHAKE,
     HA_EVENT_INTEGRATION,
     HA_EVENT_SERVICES_UPDATED,
     HA_EVENTS,
@@ -53,6 +55,7 @@ import {
     HassTranslations,
     SubscriptionUnsubscribe,
 } from '../types/home-assistant';
+import packageVersion from '../version';
 import { Credentials, HaEvent } from './';
 import {
     subscribeAreaRegistry,
@@ -540,10 +543,27 @@ export default class Websocket {
         return this.tags ?? [];
     }
 
-    getIntegrationVersion(): Promise<string> {
-        return this.send<string>({
+    async getIntegrationVersion(): Promise<string> {
+        // Probe without contrib_version first: old companions reject unknown keys.
+        const version = await this.send<string>({
             type: 'nodered/version',
         });
+        if (
+            version &&
+            version !== NO_VERSION &&
+            compareVersions(version, COMPANION_MIN_VERSION_CONTRIB_HANDSHAKE) >=
+                0
+        ) {
+            try {
+                await this.send<string>({
+                    type: 'nodered/version',
+                    contrib_version: packageVersion,
+                });
+            } catch (e) {
+                debug(`Error announcing contrib version: ${e}`);
+            }
+        }
+        return version;
     }
 
     createIntegrationEvent(type: string, version?: string): void {


### PR DESCRIPTION
Currently contrib knows the version of the companion, but the companion doesn't know the version of contrib. There's going to need to be some protocol changes to get interop to work well, so I've put in an extra handshake to allow this.

This is a small split-off ahead of the entity-availability work. A matching [companion change](https://github.com/zachowj/hass-node-red/pull/408) stores the announced package version on the config entry.

I'm going to include this as the first commit in the availability work, but thought I'd get this in ahead of that as it's kinda a separate thing.

## Summary

- On connect, after learning companion version, announce this package’s version via optional `contrib_version` on `nodered/version`.
- Probe without the field first so older companions (strict websocket schema) keep working; only announce when companion is **4.2.4+**.
- Companion stores that value ([hass-node-red#408](https://github.com/zachowj/hass-node-red/pull/408)); later availability work can treat “announced” as a capability pin.

## Stacking note

This branch currently includes #2040’s lockfile/CI commit first so CI stays green with frozen lockfiles, then the handshake commit. #2040 and #2039 are independent in substance and can be merged in either order. If they land out of the order this branch assumes, the remaining open PR(s) just need a clean rebase onto `main` (no conflict expected — disjoint files).

Fine to skip these intermediates and merge the eventual availability PR instead: that branch will carry both of these commits (plus the availability work), so merging availability alone is enough if preferred.

## Test plan

- [x] Unit suite / lint green locally
- [ ] Against companion from hass-node-red#408: config entry gains `contrib_version` after connect
- [ ] Against older companion (< 4.2.4): version probe still succeeds; no crash on unknown-key rejection path