### PR TITLE
fix(config-server): strip trailing slashes from the base URL

### DIFF
--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -1,0 +1,12 @@
+/**
+ * Normalize a Home Assistant base URL by removing surrounding whitespace and
+ * any trailing slashes.
+ *
+ * Paths are appended to the base URL as `${host}/api/...`, so a trailing slash
+ * would create a double slash, e.g. `http://localhost:8123//api/websocket`.
+ * Home Assistant matches routes on the exact path and doesn't normalize it,
+ * making every request 404.
+ */
+export function normalizeBaseUrl(url?: string): string {
+    return url ? url.trim().replace(/\/+$/, '') : '';
+}

--- a/src/homeAssistant/index.ts
+++ b/src/homeAssistant/index.ts
@@ -3,6 +3,7 @@ import { URL } from 'url';
 
 import ClientEvents from '../common/events/ClientEvents';
 import { RED } from '../globals';
+import { normalizeBaseUrl } from '../helpers/url';
 import Comms from '../nodes/config-server/Comms';
 import ConnectionLog from '../nodes/config-server/ConnectionLog';
 import EditorContext from '../nodes/config-server/EditorContext';
@@ -91,7 +92,7 @@ export function createHomeAssistantClient(
     return homeAssistant;
 }
 
-function createCredentials(
+export function createCredentials(
     credentials: Credentials,
     config: ServerNodeConfig,
 ): Credentials {
@@ -101,11 +102,14 @@ function createCredentials(
     }
     // eslint-disable-next-line camelcase
     let accessToken = credentials.access_token;
+    // Normalize before the base URL is compared or used so a trailing slash
+    // doesn't end up creating paths like `//api/websocket`
+    const baseUrl = normalizeBaseUrl(credentials.host);
 
     // Check if using HA Add-on and import proxy token
     const addonBaseUrls = ['http://hassio/homeassistant', SUPERVISOR_URL];
 
-    if (config.addon || addonBaseUrls.includes(credentials.host)) {
+    if (config.addon || addonBaseUrls.includes(baseUrl)) {
         if (!process.env.SUPERVISOR_TOKEN) {
             throw new Error('Supervisor token not found.');
         }
@@ -113,7 +117,8 @@ function createCredentials(
         // eslint-disable-next-line camelcase
         accessToken = process.env.SUPERVISOR_TOKEN;
     } else {
-        host = getBaseUrl(credentials.host);
+        validateBaseUrl(baseUrl);
+        host = baseUrl;
     }
 
     return {
@@ -158,12 +163,6 @@ function createWebsocketConfig(
         connectionDelay,
         heartbeatInterval: heartbeat,
     };
-}
-
-function getBaseUrl(url: string): string {
-    validateBaseUrl(url);
-
-    return url.trim();
 }
 
 function validateBaseUrl(baseUrl: string): string | void {

--- a/src/nodes/config-server/editor.ts
+++ b/src/nodes/config-server/editor.ts
@@ -3,6 +3,7 @@ import { EditorNodeDef, EditorNodeProperties, EditorRED } from 'node-red';
 import ha, { NodeCategory } from '../../editor/ha';
 import { i18n } from '../../editor/i18n';
 import { formatDate } from '../../helpers/date';
+import { normalizeBaseUrl } from '../../helpers/url';
 import { isNodeRedEnvVar } from '../../helpers/utils';
 import { Credentials } from '../../homeAssistant/index';
 import { DateTimeFormatOptions } from '../../types/DateTimeFormatOptions';
@@ -205,7 +206,11 @@ const ConfigServerEditor: EditorNodeDef<
     oneditsave: function () {
         const addon = $('#node-config-input-addon').is(':checked');
         const $host = $('#node-config-input-host');
-        const hostname = $host.val() as string;
+        const hostname = normalizeBaseUrl($host.val() as string);
+        // Save the normalized base URL, a trailing slash breaks the connection
+        if (hostname) {
+            $host.val(hostname);
+        }
         const haBooleanList = new Set<string>();
         $('#ha-boolean-list')
             .editableList('items')

--- a/test/unit/helpers/url.test.ts
+++ b/test/unit/helpers/url.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeBaseUrl } from '../../../src/helpers/url';
+
+describe('url', function () {
+    describe('normalizeBaseUrl', function () {
+        it('should leave a valid base URL untouched', function () {
+            expect(normalizeBaseUrl('http://localhost:8123')).toBe(
+                'http://localhost:8123',
+            );
+        });
+
+        it('should remove a trailing slash', function () {
+            expect(normalizeBaseUrl('http://localhost:8123/')).toBe(
+                'http://localhost:8123',
+            );
+        });
+
+        it('should remove multiple trailing slashes', function () {
+            expect(normalizeBaseUrl('http://localhost:8123///')).toBe(
+                'http://localhost:8123',
+            );
+        });
+
+        it('should remove surrounding whitespace', function () {
+            expect(normalizeBaseUrl('  http://localhost:8123/  ')).toBe(
+                'http://localhost:8123',
+            );
+        });
+
+        it('should keep a path prefix', function () {
+            expect(normalizeBaseUrl('https://example.com/homeassistant/')).toBe(
+                'https://example.com/homeassistant',
+            );
+        });
+
+        it('should not alter a Node-RED environment variable', function () {
+            // eslint-disable-next-line no-template-curly-in-string
+            expect(normalizeBaseUrl('${HA_URL}')).toBe(
+                // eslint-disable-next-line no-template-curly-in-string
+                '${HA_URL}',
+            );
+        });
+
+        it('should return an empty string for an empty value', function () {
+            expect(normalizeBaseUrl('')).toBe('');
+            expect(normalizeBaseUrl(undefined)).toBe('');
+        });
+    });
+});

--- a/test/unit/homeAssistant/credentials.test.ts
+++ b/test/unit/homeAssistant/credentials.test.ts
@@ -1,0 +1,128 @@
+import nock from 'nock';
+import { NodeAPI } from 'node-red';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { setRED } from '../../../src/globals';
+import { createCredentials, SUPERVISOR_URL } from '../../../src/homeAssistant';
+import HttpAPI from '../../../src/homeAssistant/Http';
+import { ServerNodeConfig } from '../../../src/types/nodes';
+
+const config = { addon: false } as ServerNodeConfig;
+
+describe('createCredentials', function () {
+    beforeAll(function () {
+        setRED({ _: (key: string) => key } as unknown as NodeAPI);
+    });
+
+    afterEach(function () {
+        vi.unstubAllEnvs();
+    });
+
+    it('should keep a base URL without a trailing slash', function () {
+        const creds = createCredentials(
+            { host: 'http://localhost:8123', access_token: '123' },
+            config,
+        );
+
+        expect(creds.host).toBe('http://localhost:8123');
+    });
+
+    // Paths are appended to the host, so a trailing slash would request
+    // `//api/websocket`, which Home Assistant answers with a 404
+    it('should strip a trailing slash from the base URL', function () {
+        const creds = createCredentials(
+            { host: 'http://localhost:8123/', access_token: '123' },
+            config,
+        );
+
+        expect(creds.host).toBe('http://localhost:8123');
+    });
+
+    it('should strip whitespace and trailing slashes from the base URL', function () {
+        const creds = createCredentials(
+            { host: ' https://example.com:8123// ', access_token: '123' },
+            config,
+        );
+
+        expect(creds.host).toBe('https://example.com:8123');
+    });
+
+    it('should keep a path prefix in the base URL', function () {
+        const creds = createCredentials(
+            { host: 'https://example.com/homeassistant/', access_token: '123' },
+            config,
+        );
+
+        expect(creds.host).toBe('https://example.com/homeassistant');
+    });
+
+    it('should use the supervisor token when the add-on option is enabled', function () {
+        vi.stubEnv('SUPERVISOR_TOKEN', 'supervisor-token');
+
+        const creds = createCredentials({ host: '', access_token: '' }, {
+            addon: true,
+        } as ServerNodeConfig);
+
+        expect(creds).toEqual({
+            host: SUPERVISOR_URL,
+            access_token: 'supervisor-token',
+        });
+    });
+
+    it('should detect an add-on base URL with a trailing slash', function () {
+        vi.stubEnv('SUPERVISOR_TOKEN', 'supervisor-token');
+
+        const creds = createCredentials(
+            { host: `${SUPERVISOR_URL}/`, access_token: '123' },
+            config,
+        );
+
+        expect(creds).toEqual({
+            host: SUPERVISOR_URL,
+            access_token: 'supervisor-token',
+        });
+    });
+
+    it('should throw an error when the base URL is empty', function () {
+        expect(() =>
+            createCredentials({ host: '/', access_token: '123' }, config),
+        ).toThrow('config-server.errors.empty_base_url');
+    });
+
+    it('should throw an error when the base URL is invalid', function () {
+        expect(() =>
+            createCredentials(
+                { host: 'not a url/', access_token: '123' },
+                config,
+            ),
+        ).toThrow('config-server.errors.invalid_base_url');
+    });
+
+    it('should throw an error when the protocol is not http(s)', function () {
+        expect(() =>
+            createCredentials(
+                { host: 'ws://localhost:8123/', access_token: '123' },
+                config,
+            ),
+        ).toThrow('config-server.errors.invalid_protocol');
+    });
+
+    it('should request paths with a single slash when the host has a trailing slash', async function () {
+        const creds = createCredentials(
+            { host: 'http://homeassistant:8123/', access_token: '123' },
+            config,
+        );
+        const httpAPI = new HttpAPI({
+            ...creds,
+            rejectUnauthorizedCerts: false,
+        });
+
+        const scope = nock('http://homeassistant:8123')
+            .get('/api/config')
+            .reply(200, 'request successful');
+        const response = await httpAPI.get('/config');
+
+        expect(response).toEqual('request successful');
+        expect(scope.isDone()).toBe(true);
+    });
+});


### PR DESCRIPTION
A trailing slash on the base URL was kept as-is, so the paths appended to it became `//api/websocket` and `//api/...`. Of course, Home Assistant matches routes on the exact path and doesn't normalize it, so every request answers 404 and the server node is left retrying the connection.

Normalize the base URL where the credentials are created, before it is compared against the add-on URLs, and write the normalized value back in the editor so an existing config is cleaned up when it is saved. This also stops a trailing slash from triggering the "Invalid format of Base URL" notification.